### PR TITLE
feat: update install and upgrade strategies

### DIFF
--- a/kubernetes/flux/config/apps.yaml
+++ b/kubernetes/flux/config/apps.yaml
@@ -46,10 +46,20 @@ spec:
                 maxHistory: 3
                 install:
                   crds: CreateReplace
+                  strategy:
+                    name: RetryOnFailure
+                    retryInterval: 2m
                 upgrade:
                   crds: CreateReplace
                   strategy:
-                    name: RetryOnFailure
+                    name: RemediateOnFailure
+                  remediation:
+                    strategy: rollback
+                    retries: 2
+                    remediateLastFailure: false
+                rollback:
+                  cleanupOnFail: true
+                  recreate: true
             target:
               group: helm.toolkit.fluxcd.io
               kind: HelmRelease

--- a/kubernetes/flux/config/apps.yaml
+++ b/kubernetes/flux/config/apps.yaml
@@ -56,7 +56,7 @@ spec:
                   remediation:
                     strategy: rollback
                     retries: 2
-                    remediateLastFailure: false
+                    remediateLastFailure: true
                 rollback:
                   cleanupOnFail: true
                   recreate: true


### PR DESCRIPTION
Thinking about HR remediation.

1. I want to ensure installs occur successfully and fixes will come immediately since I kind of watch new installs.
2. When upgrades fail, try again, in case there are any transient issues.
  a. Try twice, if continue failing, rollback to previous release
  b. Clean up the attempt
  c. Recreate pods if necessary
3. If I update the release, after a rollback, do not remediate the last failure, that would be pointless.