### PR TITLE
chore: adjust timeouts, add deletion policy

### DIFF
--- a/kubernetes/flux/config/apps.yaml
+++ b/kubernetes/flux/config/apps.yaml
@@ -23,6 +23,7 @@ spec:
       metadata:
         name: not-used
       spec:
+        deletionPolicy: WaitForTermination
         patches:
           - patch: |
               apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
1. Add deletion policy to keep noise down on terminations
2. Remove timeouts, 2.7.0 cancels healthchecks on updates.
