### PR TITLE
feat(ci): port GitHub Actions workflows for PR validation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+---
+# Path globs -> PR labels for actions/labeler (v5+ changed-files schema).
+# Labels must pre-exist in the repo (labeler applies by name; it does not create them).
+area/kubernetes:
+  - changed-files:
+      - any-glob-to-any-file: kubernetes/**
+area/talos:
+  - changed-files:
+      - any-glob-to-any-file: talos/**
+area/bootstrap:
+  - changed-files:
+      - any-glob-to-any-file: bootstrap/**
+area/renovate:
+  - changed-files:
+      - any-glob-to-any-file: "**/renovate.json5"
+area/ci:
+  - changed-files:
+      - any-glob-to-any-file: .github/**

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,49 @@
+---
+# Declarative label catalogue synced by .github/workflows/label-sync.yaml.
+# delete-other-labels:true means THIS FILE is the complete set — a label not
+# listed here is removed from the repo. Colours are 6-hex, no leading '#'.
+
+# --- Area: which part of the repo a PR touches (see .github/labeler.yml) ---
+- name: area/kubernetes
+  color: 0e8a16
+  description: Changes under kubernetes/
+- name: area/talos
+  color: 1d76db
+  description: Changes under talos/
+- name: area/bootstrap
+  color: 5319e7
+  description: Changes under bootstrap/
+- name: area/renovate
+  color: fbca04
+  description: Renovate configuration
+- name: area/ci
+  color: c5def5
+  description: Changes under .github/
+
+# --- Renovate update types (see .github/renovate.json5 automerge/labels) ---
+- name: type/major
+  color: b60205
+  description: Major version update
+- name: type/minor
+  color: fbca04
+  description: Minor version update
+- name: type/patch
+  color: 0e8a16
+  description: Patch version update
+- name: type/digest
+  color: c2e0c6
+  description: Digest update
+
+# --- Renovate datasource ---
+- name: renovate/container
+  color: ededed
+  description: Container image dependency
+- name: renovate/helm
+  color: ededed
+  description: Helm chart dependency
+- name: renovate/github-action
+  color: ededed
+  description: GitHub Action dependency
+- name: renovate/github-release
+  color: ededed
+  description: GitHub release dependency

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: flate
+on:
+  pull_request:
+    paths:
+      - kubernetes/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.resource }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  flate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        resource:
+          - kustomization
+          - helmrelease
+    steps:
+      # Comment as the purpose-robot bot app (281930), not github-actions[bot].
+      # Least-privilege: marocchino only needs to read/write PR comments.
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so flate can render the branch against main.
+          fetch-depth: 0
+
+      # Installs the flate CLI at the version this action is pinned to and
+      # exports FLATE_BASE (default: main) so `flate diff` runs changed-only.
+      - name: Setup flate
+        uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
+        with:
+          version: 0.4.10
+          cache: true
+
+      - name: flate diff
+        id: diff
+        env:
+          FLATE_PATH: ${{ github.workspace }}/kubernetes/flux/config
+        run: |
+          raw="$(mktemp)"
+          flate diff "${{ matrix.resource }}" -o github | sed '/./,$!d' > "$raw"
+          if [[ ! -s "$raw" ]]; then
+            echo "No diff for ${{ matrix.resource }} — exiting cleanly"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cp "$raw" flate-body.md
+
+      - name: Upsert PR comment
+        if: steps.diff.outputs.skip != 'true'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          header: flate:${{ matrix.resource }}
+          path: flate-body.md

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Label Sync
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yaml
+  schedule:
+    - cron: 0 0 * * * # Daily at midnight
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    name: Label Sync - Sync Labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/labels.yaml
+
+      - name: Sync Labels
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yaml
+          delete-other-labels: true

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: labels
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      # sync-labels:false unions with existing labels; never removes human ones.
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # renovate: datasource=github-releases depName=adrienverge/yamllint
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+          tool_versions: |
+            yamllint 1.38.0
+
+      - name: yamllint
+        run: yamllint --config-file .yamllint.yaml --format github .


### PR DESCRIPTION
Phase 2 of the GitHub migration: ports the PR-validation workflow set to GitHub-hosted runners, alongside the earlier Renovate migration (324fd5be2).

## Workflows

- **flate** — matrix diff (`kustomization` / `helmrelease`) rendered offline against `main`, posted as an upsertable sticky PR comment. Comments post as the **purpose-robot** bot app (281930) with a least-privilege `pull-requests: write` token; the default `GITHUB_TOKEN` is trimmed to `contents: read`. Required check scoped to `kubernetes/**` only.
- **lint** — yamllint via mise.
- **labeler** — PR auto-labelling (`sync-labels: false`, unions with human labels).
- **label-sync** — reconciles the label set from `.github/labels.yaml` (source of truth).

## Intentionally dropped

- **CodeQL** — dropped.
- **image pre-pull** — self-hosted-runner dependency, out of scope for GitHub-hosted.
- **CRD schema publishing** — no longer needed.

## Notes

- hk parity: CI runs yamllint only (oxfmt / mise-validate stay local pre-commit hooks).
- Verified clean through hk pre-commit (yamllint + oxfmt + mise).