### PR TITLE
ci: drop unsupported ruleset param

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -20,7 +20,6 @@
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["squash", "rebase"]
       }
     },


### PR DESCRIPTION
`automatic_copilot_code_review_enabled` is rejected by the GitHub rulesets API (422). Removing it so `.github/rulesets/main.json` matches what's actually applied to ruleset 3803649. No behavioural change — the live ruleset never had this param.