### PR TITLE
ci(renovate): group hk binary + hk.pkl schema

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,19 @@
       depNameTemplate: "koush/scrypted",
       autoReplaceStringTemplate: "tag: v{{{newValue}}}-noble-lite",
     },
+    // hk.pkl pins the hk release in its `amends`/`import` package URLs
+    // (github.com/jdx/hk/releases/download/v<ver>/hk@<ver>#/...). Track every
+    // version token so bumps stay in lockstep with the mise `hk` tool pin.
+    {
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)hk\\.pkl$/"],
+      matchStrings: [
+        "hk/releases/download/v(?<currentValue>\\d+\\.\\d+\\.\\d+)/",
+        "hk@(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "jdx/hk",
+    },
   ],
   packageRules: [
     // PR labels — must match the catalogue in .github/labels.yaml
@@ -78,6 +91,17 @@
       schedule: ["before 6am on Monday"],
     },
     // Groups
+    {
+      // hk binary (mise tool) + hk.pkl schema URL must move together, or the
+      // pkl won't parse against a mismatched Builtins. One PR for both. Match
+      // every form the depName may take: custom manager emits `jdx/hk`; the
+      // mise tool may normalize to `hk`, `hk/hk`, or `jdx/hk`.
+      groupName: "hk",
+      matchPackageNames: ["jdx/hk", "hk", "hk/hk"],
+      group: {
+        commitMessageTopic: "{{{groupName}}}",
+      },
+    },
     {
       groupName: "Talos Linux",
       groupSlug: "talos-linux",


### PR DESCRIPTION
hk.pkl pins the hk release in its `amends`/`import` package URLs, but nothing tracked those version tokens — they'd drift from the mise `hk` tool pin until the pkl failed to parse against a mismatched Builtins.

- **customManager** tracks the `hk@<ver>` / `releases/download/v<ver>` tokens in `hk.pkl` (datasource `github-releases`, `jdx/hk`).
- **Group `hk`** unifies that with the mise `hk` tool so both bump in a single PR. Matches `jdx/hk`/`hk`/`hk/hk` to cover however the preset's mise depName normalization resolves it.

Validated with `renovate-config-validator`.