### PR TITLE
fix(ci): quote area/bootstrap label colour to unblock Label Sync

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -11,7 +11,8 @@
   color: 1d76db
   description: Changes under talos/
 - name: area/bootstrap
-  color: 5319e7
+  # js-yaml coerces bare 5319e7 → float; quote it (PyYAML/yamllint don't, hence the disable)
+  color: "5319e7" # yamllint disable-line rule:quoted-strings
   description: Changes under bootstrap/
 - name: area/renovate
   color: fbca04


### PR DESCRIPTION
## Problem
The `Label Sync` workflow fails on `main`:
```
✗ "Parsed YAML file is invalid:\n.color should be a string (received: number, index: 2)"
```

## Root cause
`area/bootstrap`'s colour `5319e7` is valid **js-yaml** scientific notation (5319 × 10⁷), so `EndBug/label-sync` received a *number* rather than a string. Index 2 = the third label. The other 12 colours contain a hex letter that forces string parsing, so only this one tripped.

## Fix
Quote just `5319e7`. PyYAML/yamllint don't treat bare `5319e7` as a float (needs a `.` or signed exponent), so the `quoted-strings` rule flags the quote as redundant — hence the inline `# yamllint disable-line`. Verified `yamllint --strict` passes locally.