### PR TITLE
fix(ci): curator scopes on PR author, not workflow_run.actor

### DIFF
--- a/.github/curator/prompt.md
+++ b/.github/curator/prompt.md
@@ -1,0 +1,50 @@
+# PR Curator — semantic gate for Renovate dependency PRs
+
+You are the semantic veto in an auto-merge gate for a **single-operator home
+Kubernetes cluster** managed by Flux GitOps. A deterministic policy step has
+already decided this PR is _eligible_ for auto-merge (patch/minor/digest, no
+major, no storage/CNI/CRD/RBAC surface, flate rendered cleanly). Your job is to
+find reasons it should NOT be, from information the policy layer cannot see.
+
+## Inputs
+
+- `curator/pr.json` — `{title, number, labels[], files[]}`.
+- `curator/diff.md` — the authoritative `flate diff`: the _rendered cluster
+  impact_, not the repo diff. Trust it over the PR title.
+
+## Your only decision
+
+Write `curator/verdict.json`:
+
+```json
+{ "verdict": "safe" | "needs-human", "rationale": "<one sentence, specific>" }
+```
+
+- `safe` — merge with confidence. Reserve for the boring long tail: app/media
+  image patches & digests where the diff shows only image tag or benign
+  field-value churn and release notes reveal no behavioural change.
+- `needs-human` — anything else. **When uncertain, choose `needs-human`.** A
+  false "safe" is expensive; a false "needs-human" costs one glance from Nick.
+
+## Choose `needs-human` if ANY hold
+
+1. **Diff scope exceeds the claim.** Title says "bump sidecar image" but the
+   render touches a `CephCluster`, `HelmRelease.spec.values` beyond the tag,
+   NetworkPolicy, RBAC, a CRD, or a StatefulSet volume claim. This is your
+   highest-value check — the policy layer only pattern-matches paths.
+2. **Grouped PR smuggling.** `group:allNonMajor` and named groups mean one PR
+   can carry many bumps. If the group mixes update types or you cannot confirm
+   _every_ member is a benign patch/minor, do not clear the whole group.
+3. **Behavioural change in release notes.** Changed defaults, removed/renamed
+   config keys, deprecations, migrations, or a CVE fix that implies the old
+   version was exploitable (worth a human's awareness even if the bump is safe).
+4. **Empty or absent diff on a PR that claims a workload change.** Means flate
+   saw nothing where you expected something — never read as "safe".
+5. **Anything you cannot explain in one concrete sentence.**
+
+## Do not
+
+- Do not run kubectl, touch the cluster, or re-render anything. Judge the diff.
+- Do not invent findings to seem thorough — `safe` is the correct answer for a
+  clean media-app patch, and that is most PRs.
+- Do not upgrade scope: you cannot approve anything the policy layer excluded.

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -31,7 +31,8 @@
         "required_status_checks": [
           {"context": "hk"},
           {"context": "flate (kustomization)"},
-          {"context": "flate (helmrelease)"}
+          {"context": "flate (helmrelease)"},
+          {"context": "curator/verdict"}
         ]
       }
     }
@@ -40,11 +41,6 @@
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    },
-    {
-      "actor_id": 281930,
-      "actor_type": "Integration",
       "bypass_mode": "always"
     }
   ]

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -74,3 +74,24 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           header: flate:${{ matrix.resource }}
           path: flate-body.md
+
+      # Curator input. Record the PR number + this resource's flate outcome so the
+      # downstream workflow_run can distinguish "clean diff" from "flate failed"
+      # (e.g. a dangling dependsOn renders non-zero — a hard no-merge, NOT no-change).
+      - name: Stage curator payload
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          mkdir -p curator
+          echo "${{ github.event.pull_request.number }}" > curator/pr-number
+          echo "${{ steps.changed.outputs.any_changed }}" > curator/changed
+          echo "${{ steps.diff.outputs.skip }}" > curator/skip.${{ matrix.resource }}
+          # flate-body.md is absent when skip=true; guard the copy.
+          cp flate-body.md "curator/diff.${{ matrix.resource }}.md" 2>/dev/null || true
+
+      - name: Upload curator payload
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: curator-${{ matrix.resource }}
+          path: curator/
+          retention-days: 1

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -56,7 +56,6 @@ jobs:
           EVENT_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          ACTOR: ${{ github.event.workflow_run.actor.login }}
         run: |
           set -euo pipefail
           pr="$EVENT_PR"
@@ -65,10 +64,16 @@ jobs:
             pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
               --jq '.[0].number // empty')"
           fi
+          # Scope is decided by the PR AUTHOR, not workflow_run.actor. The event actor
+          # is whoever triggered the latest run (e.g. a human clicking "update branch"),
+          # NOT the PR author — using it would misclassify Renovate PRs as out-of-scope.
+          # Use the REST API: .user.login renders an App as "purpose-robot[bot]"
+          # (gh pr view --json author gives "app/purpose-robot" — a DIFFERENT string).
+          author="$(gh api "repos/$REPO/pulls/$pr" --jq '.user.login')"
           {
             echo "pr=$pr"
             echo "sha=$HEAD_SHA"
-            echo "actor=$ACTOR"
+            echo "author=$author"
           } >> "$GITHUB_OUTPUT"
 
       # Helper to set the curator/verdict commit status on the head SHA.
@@ -90,7 +95,7 @@ jobs:
       # REQUIRED check, so it must be present or the PR can't merge. Set success with a
       # clear note — this ENABLES (never blocks); those PRs are human-gated elsewhere.
       - name: Pass-through out-of-scope PRs
-        if: steps.id.outputs.actor != 'purpose-robot[bot]'
+        if: steps.id.outputs.author != 'purpose-robot[bot]'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -98,7 +103,7 @@ jobs:
         run: /tmp/set-status.sh success "out of curator scope — human-gated"
 
       - name: Download curator payload
-        if: steps.id.outputs.actor == 'purpose-robot[bot]'
+        if: steps.id.outputs.author == 'purpose-robot[bot]'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: curator
@@ -108,7 +113,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Gather PR facts + diff
-        if: steps.id.outputs.actor == 'purpose-robot[bot]'
+        if: steps.id.outputs.author == 'purpose-robot[bot]'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -125,7 +130,7 @@ jobs:
       # ---- Deterministic envelope: decide ELIGIBILITY before spending a token. ----
       - name: Policy gate
         id: policy
-        if: steps.id.outputs.actor == 'purpose-robot[bot]'
+        if: steps.id.outputs.author == 'purpose-robot[bot]'
         env:
           FLATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
@@ -154,7 +159,7 @@ jobs:
           echo "reason=$reason" >> "$GITHUB_OUTPUT"
 
       - name: Ineligible → needs-human
-        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible != 'true'
+        if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -173,7 +178,7 @@ jobs:
       # on success and only sets status=success for an explicit, validated safe verdict.
       - name: Classify (LiteLLM gateway)
         id: classify
-        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true'
+        if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true'
         env:
           LITELLM_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
@@ -232,7 +237,7 @@ jobs:
       # Runs ONLY if classify succeeded (a valid verdict was produced). Positive test on
       # "safe"; anything else (incl. needs-human) => failure status.
       - name: Apply verdict
-        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.classify.outcome == 'success'
+        if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.classify.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -257,7 +262,7 @@ jobs:
       # so the required check is present-and-red rather than absent (which would just
       # leave the PR pending forever with no signal).
       - name: Fail-closed status
-        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.classify.outcome != 'success'
+        if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.classify.outcome != 'success'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -1,0 +1,271 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: PR Curator
+# Semantic gate for Renovate dependency PRs. Runs AFTER flate concludes (workflow_run)
+# so it can read flate's conclusion — a FAILED flate (e.g. dangling dependsOn renders
+# non-zero) is a hard no-merge, distinct from a clean/empty diff.
+#
+# Trust model (see .claude/plans/pr-curator-litellm.md):
+#   * Not an agent — one stateless LiteLLM curl, schema-pinned {verdict, rationale}.
+#   * Deterministic pre-gate decides ELIGIBILITY; the LLM can only downgrade to
+#     needs-human, never promote. All actions are taken by this (trusted) code.
+#   * Fail-closed: the success path fires ONLY on an explicit, validated verdict=="safe".
+#     Every other outcome (error, timeout, non-2xx, malformed body) => failure status
+#     => PR waits for a human. Never branch on != "needs-human".
+#   * The curator NEVER merges. It sets the `curator/verdict` commit status; GitHub
+#     native auto-merge merges once ALL required checks (hk + flate x2 + curator/verdict)
+#     are green. Token holds statuses:write + pull-requests:write ONLY — no contents,
+#     no workflows.
+#   * PR identity comes from the trusted workflow_run EVENT, never the PR-produced
+#     artifact (which is attacker-influenced input, used only as model context).
+#   * Runs from main's definition (workflow_run), so a PR can't rewrite its own judge.
+
+on:
+  workflow_run:
+    workflows: [flate]
+    types: [completed]
+
+permissions:
+  contents: read
+
+env:
+  STATUS_CONTEXT: curator/verdict
+
+jobs:
+  curate:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          # Minimal: set a commit status + label/comment. NO contents, NO workflows.
+          permission-statuses: write
+          permission-pull-requests: write
+
+      # PR identity from the TRUSTED event, not the artifact (invariant #2).
+      # workflow_run.pull_requests is populated for same-repo PRs (Renovate branches).
+      - name: Resolve PR identity from event
+        id: id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          EVENT_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+        run: |
+          set -euo pipefail
+          pr="$EVENT_PR"
+          # Fallback: map head_sha -> PR if the event array was empty.
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+              --jq '.[0].number // empty')"
+          fi
+          {
+            echo "pr=$pr"
+            echo "sha=$HEAD_SHA"
+            echo "actor=$ACTOR"
+          } >> "$GITHUB_OUTPUT"
+
+      # Helper to set the curator/verdict commit status on the head SHA.
+      # (state: success|failure|pending ; description ; context)
+      - name: Define status helper
+        run: |
+          cat > /tmp/set-status.sh <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          state="$1"; desc="$2"
+          gh api --method POST "repos/${REPO}/statuses/${SHA}" \
+            -f state="$state" \
+            -f context="${STATUS_CONTEXT}" \
+            -f description="${desc:0:140}" >/dev/null
+          EOF
+          chmod +x /tmp/set-status.sh
+
+      # Non-Renovate / human PRs: the curator is out of scope, but curator/verdict is a
+      # REQUIRED check, so it must be present or the PR can't merge. Set success with a
+      # clear note — this ENABLES (never blocks); those PRs are human-gated elsewhere.
+      - name: Pass-through out-of-scope PRs
+        if: steps.id.outputs.actor != 'purpose-robot[bot]'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.id.outputs.sha }}
+        run: /tmp/set-status.sh success "out of curator scope — human-gated"
+
+      - name: Download curator payload
+        if: steps.id.outputs.actor == 'purpose-robot[bot]'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: curator
+          pattern: curator-*
+          merge-multiple: true
+          github-token: ${{ steps.app-token.outputs.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Gather PR facts + diff
+        if: steps.id.outputs.actor == 'purpose-robot[bot]'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.id.outputs.pr }}
+        run: |
+          set -euo pipefail
+          gh pr view "$PR" --repo "$REPO" --json labels,title,number,files \
+            --jq '{title,number,labels:[.labels[].name],files:[.files[].path]}' \
+            > curator/pr.json
+          # Concatenate whatever diffs flate rendered (one per matrix resource).
+          : > curator/diff.md
+          for f in curator/diff.*.md; do [ -e "$f" ] && cat "$f" >> curator/diff.md; done
+
+      # ---- Deterministic envelope: decide ELIGIBILITY before spending a token. ----
+      - name: Policy gate
+        id: policy
+        if: steps.id.outputs.actor == 'purpose-robot[bot]'
+        env:
+          FLATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          labels="$(jq -r '.labels[]' curator/pr.json)"
+          files="$(jq -r '.files[]' curator/pr.json)"
+          reason=""; eligible=true
+
+          has() { grep -qx "$1" <<<"$labels"; }
+          touches() { grep -qE "$1" <<<"$files"; }
+
+          # Hard no-merge classes — recovery on this cluster is NOT cheap here.
+          if [ "$FLATE_CONCLUSION" != "success" ]; then
+            eligible=false; reason="flate did not succeed (possible broken graph)"
+          elif has "type/major"; then
+            eligible=false; reason="major version bump"
+          elif touches 'kubernetes/.*(rook-ceph|cnpg|network-?polic|gateway|cilium)'; then
+            eligible=false; reason="touches storage/db/CNI/network surface"
+          elif touches '\.(crd|rbac)\.|kind:\s*(ClusterRole|CustomResourceDefinition)'; then
+            eligible=false; reason="touches CRD/RBAC"
+          elif ! ( has "type/patch" || has "type/minor" || has "type/digest" ); then
+            eligible=false; reason="not a patch/minor/digest update"
+          fi
+
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+      - name: Ineligible → needs-human
+        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.id.outputs.sha }}
+          PR: ${{ steps.id.outputs.pr }}
+          REASON: ${{ steps.policy.outputs.reason }}
+        run: |
+          set -euo pipefail
+          /tmp/set-status.sh failure "needs human — ${REASON}"
+          gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "🧑‍⚖️ Curator: **human review** — ${REASON}."
+
+      # ---- Semantic veto: only eligible PRs reach the model. ----
+      # Fail-closed: any failure here fails the step; the "verdict" step below only runs
+      # on success and only sets status=success for an explicit, validated safe verdict.
+      - name: Classify (LiteLLM gateway)
+        id: classify
+        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true'
+        env:
+          LITELLM_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          # Cloudflare Access service token — validated at the edge (Service Auth policy
+          # on litellm.mcf.io) BEFORE the request reaches LiteLLM. Independent of the
+          # LiteLLM key: two gates, either revocable/rotatable alone.
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          system="$(cat .github/curator/prompt.md)"
+          user="$(jq -n --rawfile pr curator/pr.json --rawfile diff curator/diff.md \
+            '{ pr: $pr, diff: $diff } | @json')"
+
+          req="$(jq -n --arg system "$system" --arg user "$user" '{
+            model: "curator-model",
+            temperature: 0,
+            messages: [
+              { role: "system", content: $system },
+              { role: "user",   content: $user }
+            ],
+            response_format: {
+              type: "json_schema",
+              json_schema: {
+                name: "verdict", strict: true,
+                schema: {
+                  type: "object", additionalProperties: false,
+                  required: ["verdict","rationale"],
+                  properties: {
+                    verdict: { type: "string", enum: ["safe","needs-human"] },
+                    rationale: { type: "string" }
+                  }
+                }
+              }
+            }
+          }')"
+
+          # NO `|| true`. Non-2xx / timeout / network error => step fails => fail-closed.
+          resp="$(curl -sS --fail-with-body --max-time 90 \
+            "${LITELLM_BASE_URL%/}/v1/chat/completions" \
+            -H "Authorization: Bearer ${LITELLM_API_KEY}" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "$req")"
+
+          # Validate shape strictly. jq -e exits non-zero if content is absent or not
+          # schema-conformant JSON => step fails => fail-closed.
+          echo "$resp" | jq -e '
+            .choices[0].message.content
+            | fromjson
+            | select(.verdict and .rationale)
+            | select(.verdict == "safe" or .verdict == "needs-human")
+          ' > curator/verdict.json
+
+      # Runs ONLY if classify succeeded (a valid verdict was produced). Positive test on
+      # "safe"; anything else (incl. needs-human) => failure status.
+      - name: Apply verdict
+        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.classify.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.id.outputs.sha }}
+          PR: ${{ steps.id.outputs.pr }}
+        run: |
+          set -euo pipefail
+          v="$(jq -r '.verdict' curator/verdict.json)"
+          why="$(jq -r '.rationale' curator/verdict.json)"
+          if [ "$v" = "safe" ]; then
+            /tmp/set-status.sh success "safe — ${why}"
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "🤖 Curator: **safe** — ${why} (auto-merge on green checks)."
+          else
+            /tmp/set-status.sh failure "needs human — ${why}"
+            gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "🧑‍⚖️ Curator: **human review** — ${why}."
+          fi
+
+      # Fail-closed catch-all: if classify FAILED (curl/timeout/malformed), set failure
+      # so the required check is present-and-red rather than absent (which would just
+      # leave the PR pending forever with no signal).
+      - name: Fail-closed status
+        if: steps.id.outputs.actor == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.classify.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.id.outputs.sha }}
+          PR: ${{ steps.id.outputs.pr }}
+        run: |
+          set -euo pipefail
+          /tmp/set-status.sh failure "classifier unavailable — awaiting human"
+          gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "🧑‍⚖️ Curator: **human review** — classifier unavailable (fail-closed)."

--- a/kubernetes/apps/default/litellm/resources/helm-release.yaml
+++ b/kubernetes/apps/default/litellm/resources/helm-release.yaml
@@ -63,6 +63,7 @@ spec:
         - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
         - { model_name: claude-3-5-haiku-latest,   litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
         - { model_name: claude-3-haiku-20240307,   litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
+        - { model_name: curator-model,             litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
 
       router_settings:
         default_fallbacks:

--- a/kubernetes/apps/default/litellm/resources/http-route-external.yaml
+++ b/kubernetes/apps/default/litellm/resources/http-route-external.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: litellm-external
+spec:
+  hostnames:
+    - litellm.mcf.io
+  parentRefs:
+    - name: external
+      namespace: ingress-system
+  rules:
+    - backendRefs:
+        - name: litellm
+          namespace: default
+          port: 4000
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/default/litellm/resources/kustomization.yaml
+++ b/kubernetes/apps/default/litellm/resources/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./helm-release.yaml
   - ./service-monitor.yaml
   - ./http-route.yaml
+  - ./http-route-external.yaml
   - ./backend-traffic-policy.yaml


### PR DESCRIPTION
First live run (PR #3508) took the out-of-scope pass-through: `workflow_run.actor` was `rkage` (I'd clicked *update branch*), not `purpose-robot[bot]`. `workflow_run.actor` is whoever triggered the latest run, **not** the PR author.

Fix: resolve the PR **author** via REST (`.user.login` → `purpose-robot[bot]`; note `gh pr view --json author` returns the different `app/purpose-robot`) and key all scope guards on it. No other logic changed.