### PR TITLE
refactor(ci): curator policy in a data file, not an if/else ladder

### DIFF
--- a/.github/curator/policy.yaml
+++ b/.github/curator/policy.yaml
@@ -1,0 +1,28 @@
+---
+# PR Curator policy — deterministic auto-merge envelope.
+# Read by .github/workflows/pr-curator.yaml. Enforced in code, NOT by the LLM: anything
+# excluded here never reaches the model. First match wins; each rule carries the reason
+# shown on the PR. Order in the workflow: flate -> exclude_labels -> exclude_paths ->
+# eligible_labels.
+
+# grep -E patterns matched against changed file paths. Highest blast radius.
+exclude_paths:
+  - regex: ^talos/
+    reason: reboots/reinstalls nodes (Talos machineconfig)
+  - regex: kubernetes/apps/system-upgrade/
+    reason: reboots/reinstalls nodes (tuppr Talos/k8s upgrade)
+  - regex: kubernetes/.*(rook-ceph|cnpg)
+    reason: touches storage/database
+  - regex: kubernetes/.*(network-?polic|gateway|cilium)
+    reason: touches CNI/network surface
+  - regex: \.(crd|rbac)\.|kind:\s*(ClusterRole|CustomResourceDefinition)
+    reason: touches CRD/RBAC
+
+exclude_labels:
+  - label: type/major
+    reason: major version bump
+
+eligible_labels:
+  - type/patch
+  - type/minor
+  - type/digest

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -80,7 +80,9 @@ jobs:
           : > curator/diff.md
           for f in curator/diff.*.md; do [ -e "$f" ] && cat "$f" >> curator/diff.md; done
 
-      # Marks a PR ineligible (never reaches the model) for classes too risky to auto-merge.
+      # Marks a PR ineligible (never reaches the model). Rules live in
+      # .github/curator/policy.yaml; first match wins. Order: flate -> labels -> paths
+      # -> eligible-type.
       - name: Policy gate
         id: policy
         if: steps.id.outputs.author == 'purpose-robot[bot]'
@@ -88,23 +90,34 @@ jobs:
           FLATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -euo pipefail
+          pol=.github/curator/policy.yaml
           labels="$(jq -r '.labels[]' curator/pr.json)"
           files="$(jq -r '.files[]' curator/pr.json)"
           reason=""; eligible=true
 
-          has() { grep -qx "$1" <<<"$labels"; }
-          touches() { grep -qE "$1" <<<"$files"; }
-
           if [ "$FLATE_CONCLUSION" != "success" ]; then
             eligible=false; reason="flate did not succeed (possible broken graph)"
-          elif has "type/major"; then
-            eligible=false; reason="major version bump"
-          elif touches 'kubernetes/.*(rook-ceph|cnpg|network-?polic|gateway|cilium)'; then
-            eligible=false; reason="touches storage/db/CNI/network surface"
-          elif touches '\.(crd|rbac)\.|kind:\s*(ClusterRole|CustomResourceDefinition)'; then
-            eligible=false; reason="touches CRD/RBAC"
-          elif ! ( has "type/patch" || has "type/minor" || has "type/digest" ); then
-            eligible=false; reason="not a patch/minor/digest update"
+          fi
+
+          if [ "$eligible" = true ]; then
+            while IFS=$'\t' read -r lbl why; do
+              [ -z "$lbl" ] && continue
+              if grep -qx "$lbl" <<<"$labels"; then eligible=false; reason="$why"; break; fi
+            done < <(yq -r '.exclude_labels[] | .label + "\t" + .reason' "$pol")
+          fi
+
+          if [ "$eligible" = true ]; then
+            while IFS=$'\t' read -r rx why; do
+              [ -z "$rx" ] && continue
+              if grep -qE "$rx" <<<"$files"; then eligible=false; reason="$why"; break; fi
+            done < <(yq -r '.exclude_paths[] | .regex + "\t" + .reason' "$pol")
+          fi
+
+          if [ "$eligible" = true ]; then
+            elig_re="$(yq -r '.eligible_labels | join("|")' "$pol")"
+            if ! grep -qE "^(${elig_re})$" <<<"$labels"; then
+              eligible=false; reason="not an eligible update type"
+            fi
           fi
 
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Moves the curator's deterministic pre-gate from an inline bash `if/else` into **`.github/curator/policy.yaml`** — `exclude_paths`, `exclude_labels`, `eligible_labels`, each with an inline `reason`. The workflow reads it with `yq` and loops (first match wins). Same behaviour, but the policy is now data in one place: readable, editable without touching workflow logic, and reusable elsewhere.

**Also closes the gap PR #3493 exposed** — folds `^talos/` and `kubernetes/apps/system-upgrade/` into the exclusions. A Talos version bump renders as a trivial two-line version-string diff but `powercycle`-reboots every node, so it must never reach the model. (This supersedes the earlier one-line fix branch.)

Verified the gate against 6 scenarios: #3493 (excluded), plex patch (eligible), major (excluded by label), rook-ceph/CRD (excluded by path), flate-failed (excluded).