### PR TITLE
feat(ci): two-step changelog pipeline (summarise then classify)

### DIFF
--- a/.github/curator/prompt.md
+++ b/.github/curator/prompt.md
@@ -8,11 +8,21 @@ find reasons it should NOT be, from information the policy layer cannot see.
 
 ## Inputs
 
-- `curator/pr.json` — `{title, number, labels[], files[], body}`. The `body`
-  contains Renovate's release-notes table and changelogs for every package in
-  the PR. Read it.
+- `curator/pr.json` — `{title, number, labels[], files[]}`.
 - `curator/diff.md` — the authoritative `flate diff`: the _rendered cluster
   impact_, not the repo diff. Trust it over the PR title.
+- `curator/changelog` — structured per-package changelog summary:
+    ```json
+    {
+      "packages": [
+        { "package": "...", "from": "x", "to": "y",
+          "flags": ["breaking_change"|"config_change"|"deprecation"|"cve_fix"],
+          "summary": "one sentence" }
+      ]
+    }
+    ```
+    An empty `flags` array and `"No changelog available"` summary is normal for
+    private container images with no public releases.
 
 ## Normal diff shapes per datasource
 
@@ -36,29 +46,28 @@ coupled set for its datasource.
 
 ## Grouped PRs
 
-Renovate groups multiple packages into one PR (e.g. `group:allNonMajor`). A
-grouped PR is **not inherently suspicious** — evaluate each member independently:
+A grouped PR is **not inherently suspicious** — evaluate each member in
+`changelog.packages` independently:
 
-- The PR body lists every package with its update type and version change.
-  Verify the group is homogeneous: all members share the same datasource label
-  and update type (all patch, or all minor, or all digest).
+- Verify all members share the same datasource label and update type.
 - Each member's diff shape should match its datasource's normal shape above.
 - If ALL members are individually safe, the group is safe.
-- Flag `needs-human` only if a member has a concerning changelog, an unexpected
-  diff shape, or the group mixes update types (e.g. a major hidden among minors).
+- Flag `needs-human` only if a member has a concerning flag, an unexpected diff
+  shape, or the group mixes update types (e.g. a major hidden among minors).
 
 ## Changelog evaluation
 
-The PR body contains Renovate's release notes. Read them for every package:
+Read `changelog.packages` for every package. The `flags` array is the authoritative
+signal — the summariser already analysed the changelog. Trust it.
 
-- **No changelog present:** normal for private/internal container images with no
-  public releases. Not grounds for `needs-human` on `renovate/container`.
-  For `renovate/helm` charts where notes are expected, absence is worth noting.
-- **Changelog present:** scan for changed defaults, removed/renamed config keys,
-  deprecations, migrations, breaking changes, or a CVE fix (implies the old
-  version was exploitable — worth human awareness even if the bump is safe).
-- A changelog showing only bug fixes, new features, or internal changes with no
-  user-facing config impact is consistent with `safe`.
+- **`flags` is empty:** no concerning changes found. This is the expected state for
+  a patch/minor bump. `summary` is explanatory context only — do NOT re-analyse it
+  to find new concerns. An empty-flags package is clear for auto-merge on changelog
+  grounds regardless of how many features the summary mentions.
+- **`flags` is empty, summary is "No changelog available":** normal for private
+  container images. Not grounds for `needs-human`.
+- **`flags` contains any of `breaking_change`, `config_change`, `deprecation`,
+  `cve_fix`:** flag `needs-human` — these warrant human awareness.
 
 ## Your only decision
 
@@ -68,10 +77,10 @@ Write `curator/verdict.json`:
 { "verdict": "safe" | "needs-human", "rationale": "<one sentence, specific>" }
 ```
 
-- `safe` — every package's diff matches its normal shape AND changelogs show no
-  behavioural impact.
-- `needs-human` — any member has an unexpected diff shape, a concerning
-  changelog, or you cannot explain the verdict in one concrete sentence.
+- `safe` — every package's diff matches its normal shape AND all `flags` arrays
+  are empty. The summariser has already cleared the changelogs.
+- `needs-human` — any member has a non-empty flag, an unexpected diff shape, or
+  you cannot explain the verdict in one concrete sentence.
   **When genuinely uncertain, choose `needs-human`.** A false "safe" is
   expensive; a false "needs-human" costs one glance from Nick.
 

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -26,7 +26,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      # Puts .github/curator/prompt.md on disk (from main's ref, not the PR branch).
+      # Puts .github/curator/ on disk (from main's ref, not the PR branch).
       - name: Checkout curator definition
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -65,7 +65,8 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      # PR metadata -> curator/pr.json; concatenated flate diffs -> curator/diff.md.
+      # PR metadata + full body -> curator/pr.json; flate diffs -> curator/diff.md.
+      # Full body is kept for fingerprinting; the summarise step distills it for the model.
       - name: Gather PR facts + diff
         if: steps.id.outputs.author == 'purpose-robot[bot]'
         env:
@@ -136,8 +137,8 @@ jobs:
           printf '🧑‍⚖️ Curator: **left for you** — %s.\n\n_Not auto-merged; review at your leisure._\n' \
             "$REASON" > curator/comment.md
 
-      # Fingerprint = sha256(prompt + rendered diff). If it matches the marker in the
-      # existing curator comment, the model already judged this exact diff — skip the call.
+      # Fingerprint covers prompt + diff + full pr.json (incl. body) so any changelog
+      # change forces re-classification, not just diff changes.
       - name: Fingerprint
         id: fp
         if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true'
@@ -157,10 +158,11 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # One LiteLLM call via Cloudflare Access. Any failure (network, non-2xx, or a
-      # response that isn't a valid {verdict, rationale}) fails the step -> not auto-merged.
-      - name: Classify (LiteLLM gateway)
-        id: classify
+      # Distil the PR body (Renovate release notes) into a compact per-package summary.
+      # Fails closed: if this step fails the classify step is skipped and the PR is left
+      # for a human via the "classifier unavailable" catch-all below.
+      - name: Summarise changelogs
+        id: summarise
         if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.fp.outputs.changed == 'true'
         env:
           LITELLM_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
@@ -169,9 +171,79 @@ jobs:
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           set -euo pipefail
+          body="$(jq -r '.body // ""' curator/pr.json)"
+
+          req="$(jq -n --arg body "$body" '{
+            model: "curator-model",
+            temperature: 0,
+            messages: [{
+              role: "user",
+              content: ("You are summarising Renovate PR release notes for a changelog reviewer.\n\nFor each package listed in the following Renovate PR body, extract:\n- package: the package name\n- from: the old version\n- to: the new version  \n- flags: array of zero or more of: breaking_change, config_change, deprecation, cve_fix\n- summary: one sentence — the most important user-facing change, or \"No changelog available\" if absent\n\nReturn only a JSON object {\"packages\":[...]}. No explanation.\n\n" + $body)
+            }],
+            response_format: {
+              type: "json_schema",
+              json_schema: {
+                name: "changelog_summary",
+                strict: true,
+                schema: {
+                  type: "object", additionalProperties: false,
+                  required: ["packages"],
+                  properties: {
+                    packages: {
+                      type: "array",
+                      items: {
+                        type: "object", additionalProperties: false,
+                        required: ["package","from","to","flags","summary"],
+                        properties: {
+                          package:  { type: "string" },
+                          from:     { type: "string" },
+                          to:       { type: "string" },
+                          flags:    { type: "array", items: {
+                            type: "string",
+                            enum: ["breaking_change","config_change","deprecation","cve_fix"]
+                          }},
+                          summary:  { type: "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }')"
+
+          resp="$(curl -sS --fail-with-body --max-time 90 \
+            "${LITELLM_BASE_URL%/}/v1/chat/completions" \
+            -H "Authorization: Bearer ${LITELLM_API_KEY}" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "$req")"
+
+          echo "$resp" | jq -e '
+            .choices[0].message.content
+            | gsub("^```json\\s*";"") | gsub("```\\s*$";"")
+            | fromjson
+            | select(.packages | type == "array")
+          ' > curator/changelog-summary.json
+
+      # Classify using the flate diff + per-package changelog summary.
+      - name: Classify (LiteLLM gateway)
+        id: classify
+        if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.fp.outputs.changed == 'true' && steps.summarise.outcome == 'success'
+        env:
+          LITELLM_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
           system="$(cat .github/curator/prompt.md)"
-          user="$(jq -n --slurpfile pr curator/pr.json --rawfile diff curator/diff.md \
-            '{ pr: $pr[0], diff: $diff } | @json')"
+          user="$(jq -n \
+            --slurpfile pr curator/pr.json \
+            --rawfile diff curator/diff.md \
+            --slurpfile changelog curator/changelog-summary.json \
+            '{ pr: ($pr[0] | del(.body)), diff: $diff, changelog: $changelog[0] } | @json')"
 
           req="$(jq -n --arg system "$system" --arg user "$user" '{
             model: "curator-model",
@@ -188,7 +260,7 @@ jobs:
                   type: "object", additionalProperties: false,
                   required: ["verdict","rationale"],
                   properties: {
-                    verdict: { type: "string", enum: ["safe","needs-human"] },
+                    verdict:   { type: "string", enum: ["safe","needs-human"] },
                     rationale: { type: "string" }
                   }
                 }
@@ -206,6 +278,7 @@ jobs:
 
           echo "$resp" | jq -e '
             .choices[0].message.content
+            | gsub("^```json\\s*";"") | gsub("```\\s*$";"")
             | fromjson
             | select(.verdict and .rationale)
             | select(.verdict == "safe" or .verdict == "needs-human")
@@ -234,10 +307,14 @@ jobs:
           fi
           printf '\n<!-- curator-fp:%s -->\n' "$FP" >> curator/comment.md
 
-      # Classifier unavailable: leave for human, no auto-merge (fail-closed). No fingerprint
-      # marker written, so the next run retries instead of treating the failure as final.
-      - name: Leave for human (classifier unavailable)
-        if: steps.id.outputs.author == 'purpose-robot[bot]' && steps.policy.outputs.eligible == 'true' && steps.fp.outputs.changed == 'true' && steps.classify.outcome != 'success'
+      # Catches: summarise failed OR classify failed. No fingerprint marker written so
+      # the next run retries. Fail-closed: a broken pipeline never auto-merges.
+      - name: Leave for human (pipeline unavailable)
+        if: >
+          steps.id.outputs.author == 'purpose-robot[bot]' &&
+          steps.policy.outputs.eligible == 'true' &&
+          steps.fp.outputs.changed == 'true' &&
+          (steps.summarise.outcome != 'success' || steps.classify.outcome != 'success')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -245,7 +322,7 @@ jobs:
         run: |
           set -euo pipefail
           gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
-          printf '🧑‍⚖️ Curator: **left for you** — classifier unavailable.\n\n_Not auto-merged (fail-closed)._\n' \
+          printf '🧑‍⚖️ Curator: **left for you** — pipeline unavailable.\n\n_Not auto-merged (fail-closed)._\n' \
             > curator/comment.md
 
       # Upserts one curator-headed comment, replacing the prior one on re-runs.


### PR DESCRIPTION
The classifier was receiving the raw PR body (up to 57k chars) and either overflowing the context window, returning markdown-fenced JSON despite `response_format`, or re-analysing summary text to invent concerns the flags had already cleared.

**Two-step LiteLLM pipeline:**

1. **Summarise** — extracts structured `{package, from, to, flags[], summary}` for every Renovate package from the raw PR body. `flags` is the authoritative signal (`breaking_change`, `config_change`, `deprecation`, `cve_fix`); empty = cleared by the summariser. Full body kept in `pr.json` for fingerprinting only.

2. **Classify** — reads diff + compact changelog summary. Prompt now explicitly instructs the model to trust the flags and not re-analyse summary text. Empty flags = changelog is clear, regardless of what features the summary mentions.

Fail-closed: summarise failure skips classify; the existing pipeline-unavailable catch-all handles both.

**Dry-run validated:**
- PR #3519 (grouped, litellm minor + private image patch): `safe` ✓
- PR #3508 (single chart patch, no changelog): `safe` ✓