### PR TITLE
feat(ci): give curator comments the Purpose Robot voice

### DIFF
--- a/.github/curator/README.md
+++ b/.github/curator/README.md
@@ -75,6 +75,16 @@ No `|| true` on the curl or the parse. A broken pipeline leaves the PR for a hum
 it never auto-merges. `needs-human` is a NORMAL outcome (not auto-merged, review
 at leisure), NOT a failure — there is no red status check for it.
 
+## Comment voice
+
+The PR comment carries a Purpose Robot (Rick and Morty) persona — deadpan,
+existentially resigned to its single task. This lives entirely in the workflow's
+deterministic `printf` templates (`🧈`, "You pass butter." on `safe`, "This
+exceeds my purpose." on handoff, "Oh my god." on fail-closed), NOT in the model.
+The LLM `rationale` stays clinical; only the wrapper is in character. Persona is
+free and risk-free here because no model is involved — do not move it into the
+prompt.
+
 ## Trust / blast-radius model
 
 Two independent gates decide whether the privileged job acts, in order:

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -145,7 +145,7 @@ jobs:
         run: |
           set -euo pipefail
           gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
-          printf '🧑‍⚖️ Curator: **left for you** — %s.\n\n_Not auto-merged; review at your leisure._\n' \
+          printf '🧈 Curator: **left for you** — %s.\n\n_This exceeds my purpose. Not auto-merged; review at your leisure._\n' \
             "$REASON" > curator/comment.md
 
       # Fingerprint covers prompt + diff + full pr.json (incl. body) so any changelog
@@ -314,11 +314,11 @@ jobs:
           why="$(jq -r '.rationale' curator/verdict.json)"
           if [ "$v" = "safe" ]; then
             gh pr merge "$PR" --repo "$REPO" --squash --auto
-            printf '🤖 Curator: **safe** — %s\n\n_Auto-merge enabled; merges on green checks._\n' \
+            printf '🧈 Curator: **safe** — %s\n\n_Auto-merge enabled; merges on green checks. You pass butter._\n' \
               "$why" > curator/comment.md
           else
             gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
-            printf '🧑‍⚖️ Curator: **left for you** — %s\n\n_Not auto-merged; review at your leisure._\n' \
+            printf '🧈 Curator: **left for you** — %s\n\n_This exceeds my purpose. Not auto-merged; review at your leisure._\n' \
               "$why" > curator/comment.md
           fi
           printf '\n<!-- curator-fp:%s -->\n' "$FP" >> curator/comment.md
@@ -338,7 +338,7 @@ jobs:
         run: |
           set -euo pipefail
           gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
-          printf '🧑‍⚖️ Curator: **left for you** — pipeline unavailable.\n\n_Not auto-merged (fail-closed)._\n' \
+          printf '🧈 Curator: **left for you** — pipeline unavailable.\n\n_Oh my god. Not auto-merged (fail-closed)._\n' \
             > curator/comment.md
 
       # Upserts one curator-headed comment, replacing the prior one on re-runs.


### PR DESCRIPTION
Deadpan Purpose Robot (Rick and Morty butter-robot) persona in the sticky comment — fitting, given the bot is literally named `purpose-robot` and its sole existence is judging dependency bumps.

- `safe` → `You pass butter.` (deadpan closer on the routine merge)
- `needs-human` → `This exceeds my purpose.`
- fail-closed → `Oh my god.`
- `🧈` signature replaces the mixed emojis.

**Lives entirely in the deterministic `printf` templates.** The LLM `rationale` stays clinical — funny wrapper, precise content. No model involvement, so zero classification risk. Documented in the curator README so the voice reads as deliberate, not the model misbehaving.