### PR TITLE
ci(labeler): run as GitHub App bot via app-token

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -6,15 +6,23 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
       # sync-labels:false unions with existing labels; never removes human ones.
       - name: Apply Labels
         uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/labeler.yml
           sync-labels: false


### PR DESCRIPTION
Apply PR labels as the repo's GitHub App bot instead of `github-actions[bot]`.

- Mint an app token with `create-github-app-token` (same SHA-pinned action + secrets as the renovate and flate workflows) with `permission-pull-requests: write`.
- Pass it to `actions/labeler` via `repo-token`.
- Drop the now-unused `pull-requests: write` from the default `GITHUB_TOKEN`, leaving `contents: read` to match renovate/flate.