### PR TITLE
fix(plex): defeat mergerfs-over-NFS stale handles on media mount

### DIFF
--- a/kubernetes/apps/default/plex/resources/media-mount.yaml
+++ b/kubernetes/apps/default/plex/resources/media-mount.yaml
@@ -12,8 +12,14 @@ spec:
     - ReadOnlyMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
-  # Delta over /etc/nfsmount.conf only. Global conf still supplies defaults
+  # Client tuning for mergerfs-over-NFS: an *arr replacing a file drops the
+  # mergerfs node, so force a fresh LOOKUP per access instead of trusting a
+  # readdirplus batch — otherwise Plex holds a stale handle (ESTALE) until it
+  # is restarted. Delta over /etc/nfsmount.conf defaults.
   mountOptions:
+    - hard
+    - nordirplus
+    - lookupcache=none
     - actimeo=20
   nfs:
     server: 10.46.100.100 # Use IP instead of nfs-server.default.svc.cluster.local


### PR DESCRIPTION
## Problem

Media files that an *arr **replaces** (proper/upgrade/redownload) intermittently become unscannable in Plex — `ls -l` shows them as `-?????????` (a stale NFS file handle / ESTALE). Restarting the Plex pod fixes it, which proves the stale state lives in Plex's NFS client cache, not on the server.

## Root cause

The mergerfs pool is re-exported over NFS. mergerfs' `never-forget-nodes=true` keeps a node alive *until it is unlinked, removed, or **replaced***. The *arr apps' whole job is replacing files, which is the one case the option can't cover — the old node is dropped and Plex is left holding a stale handle. The server config already follows mergerfs' NFS guidance (`never-forget-nodes`, `inodecalc=path-hash`, `fsid=UUID`); the gap is that the read client caches the stale handle hard and never revalidates.

## Fix

Tune the read-only `plex-media` PV mount so the client self-heals instead of needing a restart:

- `nordirplus` — stat each entry with a fresh LOOKUP rather than trusting a readdirplus batch (directly targets the `-?????????` output)
- `lookupcache=none` — re-LOOKUP by name per access, so a replaced node is picked up immediately
- `hard` kept explicit (no soft-mount write-integrity trade; backend-down is already handled by the KEDA `nfs-scaler`), `actimeo=20` retained

PV `mountOptions` are mutable in place (verified via server dry-run) — Flux patches the existing PV, no recreate. Options apply on the next remount, so Plex needs a bounce after reconcile.

## Refs

- [mergerfs — Remote Filesystems (NFS export)](https://github.com/trapexit/mergerfs/blob/master/mkdocs/docs/remote_filesystems.md)
- [NFS Stale file handle · mergerfs#576](https://github.com/trapexit/mergerfs/issues/576)