### PR TITLE
fix(ci): curator survives PRs that touch no kubernetes path

### DIFF
--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -78,6 +78,8 @@ jobs:
 
       # PR metadata + full body -> curator/pr.json; flate diffs -> curator/diff.md.
       # Full body is kept for fingerprinting; the summarise step distills it for the model.
+      # A PR touching no kubernetes/** path uploads no curator artifact, so the dir is
+      # absent here — create it and carry on with an empty diff (changelog-driven verdict).
       - name: Gather PR facts + diff
         if: steps.id.outputs.is_bot == 'true'
         env:
@@ -86,6 +88,7 @@ jobs:
           PR: ${{ steps.id.outputs.pr }}
         run: |
           set -euo pipefail
+          mkdir -p curator
           gh pr view "$PR" --repo "$REPO" --json labels,title,number,files,body \
             --jq '{title,number,labels:[.labels[].name],files:[.files[].path],body}' \
             > curator/pr.json


### PR DESCRIPTION
## Problem

PR #3529 (a `renovatebot/github-action` patch bump) failed the **PR Curator** run. The bump touches only `.github/workflows/renovate.yaml`, so flate's `changed-files` gate sets `any_changed=false` and **never uploads the `curator-*` artifact**. flate still concludes `success`, the curator fires, sees the bot author, finds no artifact (so no `curator/` dir), and `Gather PR facts + diff` dies on `> curator/pr.json: No such file or directory`.

This hits a whole class of bot PRs — anything changing only `.github/**`.

## Fix

`mkdir -p curator` at the top of the gather step. `curator/diff.md` is then empty (no cluster diff, which is correct for a github-action bump) and the pipeline classifies from the Renovate changelog as designed. The `exclude_paths` regexes are all `kubernetes/`/`talos/`, so a `.github/` path stays eligible.

Once merged, re-running the curator on #3529 will classify it instead of crashing.