### PR TITLE
fix(ci): curator reads PR facts via REST, not GraphQL

### DIFF
--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -89,8 +89,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p curator
-          gh pr view "$PR" --repo "$REPO" --json labels,title,number,files,body \
-            --jq '{title,number,labels:[.labels[].name],files:[.files[].path],body}' \
+          # PR facts via the REST pull + files endpoints, which the app token reads even
+          # for PRs editing .github/workflows/**. REST names the path field `filename`.
+          pr="$(gh api "repos/$REPO/pulls/$PR")"
+          files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+            | jq -R . | jq -s 'map(select(length > 0))')"
+          jq -n --argjson pr "$pr" --argjson files "$files" \
+            '{title: $pr.title, number: $pr.number, labels: [$pr.labels[].name],
+              files: $files, body: ($pr.body // "")}' \
             > curator/pr.json
           : > curator/diff.md
           for f in curator/diff.*.md; do [ -e "$f" ] && cat "$f" >> curator/diff.md; done


### PR DESCRIPTION
## Problem

Follow-up to #3530. With the `curator/` dir now created, PR #3529 still fails the curator at `Gather PR facts + diff` — deterministically, zero stdout/stderr, `exit 1` in ~0.3s.

Root cause: `gh pr view` uses **GraphQL**, and its PR `files` connection returns a silent 403 for the curator's app token, which is minted with `contents` + `pull-requests` but **no `workflows` permission**. GitHub restricts that connection on any PR editing `.github/workflows/**` — which is every github-action bump (#3529 touches `.github/workflows/renovate.yaml`). The earlier success case was a `kubernetes/**` PR, so GraphQL never tripped the restriction. The `Resolve PR identity` step in the same job works because it uses `gh api` (REST).

## Fix

Build `curator/pr.json` from the REST pull + files endpoints instead of GraphQL — the same REST path the identity step already uses successfully. REST names the changed-path field `filename` (GraphQL calls it `path`). Output shape is identical, validated locally against #3529.

Deliberately **not** granting the app `workflows: write`: it would let the bot rewrite CI for no benefit over a REST read.

Once merged, re-running the curator on #3529 will classify it instead of crashing.