### PR TITLE
fix(ci): curator gather trips set -e on empty diff glob

### DIFF
--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -88,9 +88,10 @@ jobs:
           PR: ${{ steps.id.outputs.pr }}
         run: |
           set -euo pipefail
+          trap 'echo "::error::gather step failed at line $LINENO" >&2' ERR
           mkdir -p curator
-          # PR facts via the REST pull + files endpoints, which the app token reads even
-          # for PRs editing .github/workflows/**. REST names the path field `filename`.
+          # PR facts via the REST pull + files endpoints. REST names the changed-path
+          # field `filename`.
           pr="$(gh api "repos/$REPO/pulls/$PR")"
           files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
             | jq -R . | jq -s 'map(select(length > 0))')"
@@ -98,8 +99,11 @@ jobs:
             '{title: $pr.title, number: $pr.number, labels: [$pr.labels[].name],
               files: $files, body: ($pr.body // "")}' \
             > curator/pr.json
+          # nullglob: an unmatched pattern expands to nothing, so the concat loop runs
+          # zero times instead of iterating once over the literal glob.
+          shopt -s nullglob
           : > curator/diff.md
-          for f in curator/diff.*.md; do [ -e "$f" ] && cat "$f" >> curator/diff.md; done
+          for f in curator/diff.*.md; do cat "$f" >> curator/diff.md; done
 
       # Marks a PR ineligible (never reaches the model). Rules live in
       # .github/curator/policy.yaml; first match wins. Order: flate -> labels -> paths


### PR DESCRIPTION
## Problem

Third and actual root cause. #3530 (mkdir) and #3531 (REST) were both necessary hardening but **neither fixed the failure** — I misdiagnosed. The curator still fails at `Gather PR facts + diff` on #3529: deterministic, **zero stderr**, exit 1.

The tell: `gh api` on a 403 prints a loud stderr message (verified), and the very first pre-fix failure captured its shell stderr fine — yet every failing run shows nothing. A `set -e` exit, by contrast, prints **nothing**. The only silent-failing command is the last line:

```bash
for f in curator/diff.*.md; do [ -e "$f" ] && cat "$f" >> curator/diff.md; done
```

A bot PR touching no `kubernetes/**` path uploads no curator artifact → no `curator/diff.*.md` files → the glob stays literal → `[ -e ]` returns 1 → the loop's final status trips `set -e`. Ubuntu's bash 5.2 exits here; my local bash 3.2 exempts it, which is why it reproduced only in CI. The success case worked because a `kubernetes/**` PR *has* diff files, so the glob matches and the loop exits 0.

## Fix

`shopt -s nullglob` so an unmatched pattern expands to nothing and the loop runs zero times. Added an `ERR` trap that emits `::error::gather step failed at line N` — so any future non-zero exit in this step names itself instead of failing silently.

Verified the nullglob form exits 0 on an empty match locally.