### PR TITLE
feat(litellm): route Haiku to the Anthropic API with prompt caching

### DIFF
--- a/kubernetes/apps/default/litellm/resources/external-secret.yaml
+++ b/kubernetes/apps/default/litellm/resources/external-secret.yaml
@@ -17,3 +17,6 @@ spec:
     - secretKey: TAVILY_API_KEY
       remoteRef:
         key: litellm/tavily/credential
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: anthropic/credential

--- a/kubernetes/apps/default/litellm/resources/helm-release.yaml
+++ b/kubernetes/apps/default/litellm/resources/helm-release.yaml
@@ -58,11 +58,11 @@ spec:
         - { model_name: claude-sonnet-4-6,         litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
         - { model_name: claude-sonnet-4-5,         litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
         - { model_name: claude-sonnet-5,           litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
-        - { model_name: claude-haiku-4-5,          litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
-        - { model_name: claude-haiku-4-5-20251001, litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
-        - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
-        - { model_name: claude-3-5-haiku-latest,   litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
-        - { model_name: claude-3-haiku-20240307,   litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
+        - { model_name: claude-haiku-4-5,          litellm_params: { model: anthropic/claude-haiku-4-5-20251001, api_key: os.environ/ANTHROPIC_API_KEY } }
+        - { model_name: claude-haiku-4-5-20251001, litellm_params: { model: anthropic/claude-haiku-4-5-20251001, api_key: os.environ/ANTHROPIC_API_KEY } }
+        - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: anthropic/claude-3-5-haiku-20241022, api_key: os.environ/ANTHROPIC_API_KEY } }
+        - { model_name: claude-3-5-haiku-latest,   litellm_params: { model: anthropic/claude-3-5-haiku-latest, api_key: os.environ/ANTHROPIC_API_KEY } }
+        - { model_name: claude-3-haiku-20240307,   litellm_params: { model: anthropic/claude-3-haiku-20240307, api_key: os.environ/ANTHROPIC_API_KEY } }
         - { model_name: curator-model,             litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
 
       router_settings:


### PR DESCRIPTION
## What

Every `claude-haiku-*` model name in the LiteLLM `model_list` was aliased to `github_copilot/gpt-4o-mini` — so the Haiku slot (Claude Code / claude-acp background + small-fast tasks) never actually served Haiku.

- Point all five Haiku-family names at their **real** Anthropic model via the `anthropic/` provider (no silent upgrade — `claude-3-5-haiku-*` stays 3.5, not 4.5).
- New `ANTHROPIC_API_KEY` in the ExternalSecret, sourced from `anthropic/credential`; reaches LiteLLM via the existing `environmentSecrets: [litellm-env]`.
- Drop the `*z` cost-zeroing anchor on these entries so LiteLLM's built-in cost map reports `cache_creation`/`cache_read` tokens instead of forcing them to 0 (correct for a metered provider, unlike flat-rate Copilot).

## Prompt caching

No switch to flip — Claude Code already emits `cache_control` breakpoints; the `anthropic` provider passes them through and `drop_params: true` doesn't strip them. Dropping `*z` is what surfaces cached-token usage in the Prometheus cost metrics.

## Notes

- The Haiku slot now bills the real Anthropic key (small, metered) instead of flat-rate Copilot.
- `curator-model` intentionally left on `github_copilot/gpt-4o-mini`.
- Requires the `anthropic/credential` 1Password item to exist before Flux reconciles.