### PR TITLE
fix(ci): truncate flate diff to fit GitHub's comment limit

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -61,10 +61,22 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # GitHub caps a comment body at 65536 chars. A wide renovate batch can
+          # exceed that, so trim the diff to fit and link the full render.
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          notice="> Diff truncated — it exceeds GitHub's 65536-char comment limit. Full render in the [workflow run](${run_url})."
+          # Reserve headroom for the code fence, the notice, and the sticky-comment marker.
+          max_raw=$(( 65536 - ${#notice} - 256 ))
+          if [[ $(wc -c < "$raw") -gt $max_raw ]]; then
+            head -c "$max_raw" "$raw" | sed '$d' > "$raw.trunc"
+            mv "$raw.trunc" "$raw"
+            truncated=true
+          fi
           {
             printf '```diff\n'
             cat "$raw"
             printf '\n```\n'
+            [[ "${truncated:-}" == "true" ]] && printf '\n%s\n' "$notice"
           } > flate-body.md
 
       - name: Upsert PR comment


### PR DESCRIPTION
PR #3539's `flate (helmrelease)` leg failed with `Body is too long (maximum is 65536 characters)` — a wide renovate batch rendered a diff past GitHub's comment-body cap.

Trim the diff to fit under the limit and append a notice linking the full render in the workflow run. Kustomization leg was unaffected (smaller diff) but gets the same guard.