### PR TITLE
fix(ci): stop flate render exiting 1 on the non-truncated path

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -76,7 +76,7 @@ jobs:
             printf '```diff\n'
             cat "$raw"
             printf '\n```\n'
-            [[ "${truncated:-}" == "true" ]] && printf '\n%s\n' "$notice"
+            if [[ "${truncated:-}" == "true" ]]; then printf '\n%s\n' "$notice"; fi
           } > flate-body.md
 
       - name: Upsert PR comment


### PR DESCRIPTION
Follow-up to #3541. The truncation guard ended with `[[ "${truncated:-}" == "true" ]] && printf ...` as the last statement in the block. Under GitHub's `bash -e`, a false test returns 1 → the step exits 1 whenever the diff is small enough to skip truncation. That's why #3539's `kustomization` leg failed while `helmrelease` (truncated → test true) passed.

Swap the short-circuit for an explicit `if`. Verified both paths exit 0 under `set -e`.