### PR TITLE
chore(renovate): drop Age/Confidence PR columns

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,8 @@
     "github>home-operations/renovate-presets#2.1.0",
     "group:allNonMajor",
   ],
+  // Drop the Age/Confidence PR columns — Merge Confidence never scores docker/OCI.
+  ignorePresets: ["mergeConfidence:age-confidence-badges"],
   customManagers: [
     // Scrypted pins a `ghcr.io/koush/scrypted:<semver>-noble-lite` tag; track the upstream
     // GitHub release and rewrite only the semver portion, preserving the `-noble-lite` suffix.


### PR DESCRIPTION
Merge Confidence only scores language datasources (npm/pypi/…), never docker/OCI, so the Age/Confidence columns render empty on this container-and-Helm stack.

Ignore `mergeConfidence:age-confidence-badges` (pulled in via `config:recommended`); `prBodyColumns` reverts to the Renovate default.