### PR TITLE
feat(curator): request reviewers on needs-human verdict

### DIFF
--- a/.github/curator/policy.yaml
+++ b/.github/curator/policy.yaml
@@ -26,3 +26,7 @@ eligible_labels:
   - type/patch
   - type/minor
   - type/digest
+
+# GitHub logins requested as reviewers when the classifier returns needs-human.
+reviewers:
+  - rkage

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -341,6 +341,8 @@ jobs:
               "$why" > curator/comment.md
           else
             gh pr edit "$PR" --repo "$REPO" --add-label "curator/needs-human" || true
+            reviewers="$(yq -r '.reviewers // [] | join(",")' .github/curator/policy.yaml)"
+            [ -n "$reviewers" ] && gh pr edit "$PR" --repo "$REPO" --add-reviewer "$reviewers" || true
             printf '🧈 Curator: **left for you** — %s\n\n_This exceeds my purpose. Not auto-merged; review at your leisure._\n' \
               "$why" > curator/comment.md
           fi


### PR DESCRIPTION
## What

On a `needs-human` classification, the curator now requests reviewers on the PR (in addition to the `curator/needs-human` label + comment).

## How

- **`policy.yaml`** — new `reviewers:` array (`rkage`) as the single source of truth; add more logins to request them all.
- **`pr-curator.yaml`** — the needs-human branch of *Apply verdict* reads `reviewers` via `yq`, joins comma-separated, and calls `gh pr edit --add-reviewer`. Guarded so an empty array is a no-op and an already-requested/author reviewer won't fail the step.

## Scope

LLM verdict path only. Policy-ineligible and pipeline-unavailable outcomes keep just the label — unchanged.

## Why not CODEOWNERS

Code owners are auto-requested on *every* matching PR at open time, which would tag the reviewer on the safe auto-merged PRs too — defeating the silent auto-merge path. Requesting in the one workflow branch keeps it to genuine needs-human cases.