### PR TITLE
fix(ci): define curator/needs-human label so it can actually apply

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -48,3 +48,8 @@
 - name: renovate/github-release
   color: ededed
   description: GitHub release dependency
+
+# --- PR Curator (see .github/workflows/pr-curator.yaml) ---
+- name: curator/needs-human
+  color: d93f0b
+  description: Curator left this PR for human review


### PR DESCRIPTION
## Bug

The curator has added the `curator/needs-human` label since #3509, but that label was **never defined in `labels.yaml`**. Because `label-sync` runs with `delete-other-labels: true`, the label cannot exist in the repo — so every `gh pr edit --add-label curator/needs-human` has silently failed (swallowed by `|| true`). No PR has ever actually carried the label; only the curator *comment* was visible (e.g. #3546).

Knock-on: #3548's reviewer-request step keys off this label, so it never fired.

## Fix

Add `curator/needs-human` to `labels.yaml`. Merging triggers `label-sync` (it runs on push to `main` touching that file), which creates the label. From then on `--add-label` sticks and the reviewer step fires on every human-left PR.

## Verify after merge

- `gh label list --search curator` shows the label
- Next Renovate PR left for a human carries `curator/needs-human` **and** requests the `reviewers` from `policy.yaml`