### PR TITLE
feat(litellm): route Haiku back through Copilot

### DIFF
--- a/kubernetes/apps/default/litellm/resources/helm-release.yaml
+++ b/kubernetes/apps/default/litellm/resources/helm-release.yaml
@@ -58,11 +58,11 @@ spec:
         - { model_name: claude-sonnet-4-6,         litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
         - { model_name: claude-sonnet-4-5,         litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
         - { model_name: claude-sonnet-5,           litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
-        - { model_name: claude-haiku-4-5,          litellm_params: { model: anthropic/claude-haiku-4-5-20251001, api_key: os.environ/ANTHROPIC_API_KEY } }
-        - { model_name: claude-haiku-4-5-20251001, litellm_params: { model: anthropic/claude-haiku-4-5-20251001, api_key: os.environ/ANTHROPIC_API_KEY } }
-        - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: anthropic/claude-3-5-haiku-20241022, api_key: os.environ/ANTHROPIC_API_KEY } }
-        - { model_name: claude-3-5-haiku-latest,   litellm_params: { model: anthropic/claude-3-5-haiku-latest, api_key: os.environ/ANTHROPIC_API_KEY } }
-        - { model_name: claude-3-haiku-20240307,   litellm_params: { model: anthropic/claude-3-haiku-20240307, api_key: os.environ/ANTHROPIC_API_KEY } }
+        - { model_name: claude-haiku-4-5,          litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
+        - { model_name: claude-haiku-4-5-20251001, litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
+        - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
+        - { model_name: claude-3-5-haiku-latest,   litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
+        - { model_name: claude-3-haiku-20240307,   litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
         - { model_name: curator-model,             litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
 
       router_settings:


### PR DESCRIPTION
Copilot's license serves `claude-haiku-4.5` again, so drop the direct Anthropic API detour (`ANTHROPIC_API_KEY`) and map every Haiku alias to `github_copilot/claude-haiku-4.5` — matching the alias-in → dotted-slug-out convention and restoring the 0× cache-cost `model_info: *z`.

## Verified against the live proxy
- `github_copilot/claude-haiku-4.5` (new target) completes on the Copilot license.
- `claude-haiku-4-5` alias responds.
- Curator's `strict: true` json_schema request returns schema-conforming JSON on Haiku.

## Notes
- `ANTHROPIC_API_KEY` is now unused by the config (still present in the `litellm-env` secret; not pruned here).
- Curator still runs on `curator-model` → `github_copilot/gpt-4o-mini` (0× premium); only validated Haiku works, did not switch it.