### PR TITLE
refactor(curator): gate on rendered kinds, drop brittle source-path rules

### DIFF
--- a/.github/curator/README.md
+++ b/.github/curator/README.md
@@ -14,8 +14,8 @@ only acts on what Renovate did not.
 ## Two-layer design (the core principle)
 
 1. **Deterministic pre-gate (`policy.yaml`, enforced in the workflow).** Decides
-   eligibility from labels + changed paths + flate conclusion. Anything excluded
-   here NEVER reaches the model. This holds the real veto.
+   eligibility from labels + the rendered flate diff + flate conclusion. Anything
+   excluded here NEVER reaches the model. This holds the real veto.
 2. **LLM classifier (`prompt.md`, run via LiteLLM).** Only judges PRs the
    pre-gate already deemed eligible. It can veto (`needs-human`) but never
    promote — it cannot approve anything the pre-gate excluded.
@@ -26,13 +26,37 @@ are taken by deterministic workflow code.
 
 ## Why the pre-gate is non-negotiable
 
-The model cannot see blast radius that isn't in the diff. A Talos version bump
-(`v1.13.5 → v1.13.6`) renders as a trivial two-line version-string change but
-`powercycle`-reboots every node. Asked directly, the model calls it `safe` — the
-reboot implication isn't in the diff. `policy.yaml` excludes `^talos/` and
-`kubernetes/apps/system-upgrade/` so it never reaches the model. Same reasoning
-for storage/CNI/CRD/RBAC. **Do not move exclusions into the prompt** — that makes
-the highest-blast-radius decisions probabilistic.
+The model cannot see blast radius that isn't legible in the diff. A tuppr
+`TalosUpgrade` version bump (`v1.13.5 → v1.13.6`) renders as a trivial two-line
+version-string change but `powercycle`-reboots every node; asked directly, the model
+calls it `safe`. So the gate is deterministic and runs before the model. **Do not move
+exclusions into the prompt** — that makes the highest-blast-radius decisions probabilistic.
+
+## Gate on the render, not paths
+
+`policy.yaml`'s `exclude_rendered` greps the rendered `flate` diff (`curator/diff.md`) for
+dangerous kinds / API-groups — the `TalosUpgrade`/`KubernetesUpgrade` reboot CRs, RBAC,
+webhooks, storage (`ceph.rook.io`, `storage.k8s.io`), database (`cnpg.io`), and network
+(`gateway.networking.k8s.io`, NetworkPolicy, cilium). The render is the source of truth: a
+change reaches the cluster only if flate renders it, wherever the source path lives.
+Source-**path** rules were dropped — a chart bump changes one version string on disk while
+Flux re-renders its upstream templates, so the risky object surfaces in the render under a
+path no rule anticipated (the whack-a-mole). Concrete miss this catches: PR #3552
+(external-secrets `2.7.0 → 2.8.0`) rendered a `ClusterRole` change behind a one-line
+OCIRepository tag bump; a path gate saw nothing. Over-matching is the safe direction — a
+false `needs-human` costs one glance.
+
+`talos/` is covered without a path rule: a Renovate Talos/k8s bump edits the
+`TalosUpgrade`/`KubernetesUpgrade` CR (which renders and is matched above), and the
+`talos/` machineconfig itself is `mise`/`talosctl`-driven — never a Renovate PR, so it
+can't reach this gate.
+
+The one accepted gap is **CRDs**: flate's `--skip-crds` default strips
+`CustomResourceDefinition` objects from the render — kustomize- and Helm-sourced alike
+since flate #182 — so a CRD change is invisible here. A recoverable gap (a bad CRD is a Git
+revert); closing it means `--skip-crds=false`, which floods every human-facing flate
+comment with OpenAPI schemas and risks truncating the curator's own `diff.md`. Not worth it
+for recoverable risk.
 
 ## Pipeline (in order)
 

--- a/.github/curator/policy.yaml
+++ b/.github/curator/policy.yaml
@@ -2,21 +2,33 @@
 # PR Curator policy — deterministic auto-merge envelope.
 # Read by .github/workflows/pr-curator.yaml. Enforced in code, NOT by the LLM: anything
 # excluded here never reaches the model. First match wins; each rule carries the reason
-# shown on the PR. Order in the workflow: flate -> exclude_labels -> exclude_paths ->
+# shown on the PR. Order in the workflow: flate -> exclude_labels -> exclude_rendered ->
 # eligible_labels.
 
-# grep -E patterns matched against changed file paths. Highest blast radius.
-exclude_paths:
-  - regex: ^talos/
-    reason: reboots/reinstalls nodes (Talos machineconfig)
-  - regex: kubernetes/apps/system-upgrade/
-    reason: reboots/reinstalls nodes (tuppr Talos/k8s upgrade)
-  - regex: kubernetes/.*(rook-ceph|cnpg)
-    reason: touches storage/database
-  - regex: kubernetes/.*(network-?polic|gateway|cilium)
-    reason: touches CNI/network surface
-  - regex: \.(crd|rbac)\.|kind:\s*(ClusterRole|CustomResourceDefinition)
-    reason: touches CRD/RBAC
+# grep -E patterns matched against the RENDERED flate diff (curator/diff.md), not source
+# paths. The render is the source of truth — a change reaches the cluster only if flate
+# renders it, wherever the source lives — so we gate on the rendered kind/API-group, not
+# paths a chart can relocate (the whack-a-mole). flate annotates each hunk
+# `# <group>/<version>/<Kind>/<name>`. One accepted gap: CRDs. flate --skip-crds (default
+# true) strips them from the render, kustomize- and Helm-sourced alike (flate #182), so a
+# CRD change is invisible here — recoverable (Git revert), not worth flooding every diff
+# with OpenAPI schemas. (talos/ never renders either, but it's mise/talosctl-driven, never
+# a bot PR — and a Renovate Talos bump hits the TalosUpgrade CR below, so it's covered.)
+exclude_rendered:
+  - regex: /(Talos|Kubernetes)Upgrade/
+    reason: reboots/reinstalls nodes (tuppr Talos/k8s upgrade CR)
+  - regex: ceph\.rook\.io
+    reason: touches storage (rook-ceph)
+  - regex: cnpg\.io
+    reason: touches database (cnpg)
+  - regex: rbac\.authorization\.k8s\.io
+    reason: renders an RBAC (Cluster)Role/binding change
+  - regex: admissionregistration\.k8s\.io
+    reason: renders an admission-webhook change
+  - regex: storage\.k8s\.io|/PersistentVolumeClaim/
+    reason: renders storage surface
+  - regex: gateway\.networking\.k8s\.io|/NetworkPolicy/|cilium\.io
+    reason: renders network/ingress surface
 
 exclude_labels:
   - label: type/major

--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -114,7 +114,7 @@ jobs:
           for f in curator/diff.*.md; do cat "$f" >> curator/diff.md; done
 
       # Marks a PR ineligible (never reaches the model). Rules live in
-      # .github/curator/policy.yaml; first match wins. Order: flate -> labels -> paths
+      # .github/curator/policy.yaml; first match wins. Order: flate -> labels -> rendered
       # -> eligible-type.
       - name: Policy gate
         id: policy
@@ -125,26 +125,26 @@ jobs:
           set -euo pipefail
           pol=.github/curator/policy.yaml
           labels="$(jq -r '.labels[]' curator/pr.json)"
-          files="$(jq -r '.files[]' curator/pr.json)"
           reason=""; eligible=true
+
+          # First matching rule in <key> wins and sets the ineligibility reason. <field> is
+          # the rule key to test (label|regex); <flags> pick exact (-qx) or regex (-qE) match.
+          exclude() {
+            [ "$eligible" = true ] || return 0
+            local key=$1 field=$2 flags=$3 haystack=$4 pat why
+            while IFS=$'\t' read -r pat why; do
+              [ -z "$pat" ] && continue
+              if grep "$flags" "$pat" <<<"$haystack"; then eligible=false; reason="$why"; return 0; fi
+            done < <(yq -r ".${key}[] | .${field} + \"\t\" + .reason" "$pol")
+          }
 
           if [ "$FLATE_CONCLUSION" != "success" ]; then
             eligible=false; reason="flate did not succeed (possible broken graph)"
           fi
 
-          if [ "$eligible" = true ]; then
-            while IFS=$'\t' read -r lbl why; do
-              [ -z "$lbl" ] && continue
-              if grep -qx "$lbl" <<<"$labels"; then eligible=false; reason="$why"; break; fi
-            done < <(yq -r '.exclude_labels[] | .label + "\t" + .reason' "$pol")
-          fi
-
-          if [ "$eligible" = true ]; then
-            while IFS=$'\t' read -r rx why; do
-              [ -z "$rx" ] && continue
-              if grep -qE "$rx" <<<"$files"; then eligible=false; reason="$why"; break; fi
-            done < <(yq -r '.exclude_paths[] | .regex + "\t" + .reason' "$pol")
-          fi
+          exclude exclude_labels   label -qx "$labels"
+          # The render is the source of truth; an empty diff.md matches nothing.
+          exclude exclude_rendered regex -qE "$(cat curator/diff.md 2>/dev/null || true)"
 
           if [ "$eligible" = true ]; then
             elig_re="$(yq -r '.eligible_labels | join("|")' "$pol")"


### PR DESCRIPTION
## What

Collapse the curator's two exclusion mechanisms (`exclude_paths` + `exclude_rendered`) into **one** deny-list of dangerous kinds / API-groups, grepped against the rendered `flate` diff.

## Why

The render is the source of truth — a change reaches the cluster only if `flate` renders it, wherever the source path lives. Source-**path** rules are brittle: a chart bump edits one version string on disk while Flux re-renders the upstream templates, so the risky object surfaces in the render under a path no rule anticipated (the whack-a-mole). Gating on the rendered **kind** is stable wherever the chart relocates its files.

Concrete class this catches — **PR #3552**: external-secrets `2.7.0 → 2.8.0` rendered a `ClusterRole` change behind a one-line OCIRepository tag bump and auto-merged. A path gate saw nothing; the `rbac.authorization.k8s.io` render rule does.

## Coverage notes

- Every former path rule has a working rendered equivalent: rook → `ceph.rook.io`, cnpg → `cnpg.io`, system-upgrade → `TalosUpgrade`/`KubernetesUpgrade`, RBAC/webhooks/storage/network → their API-groups.
- `talos/` stays covered without a path rule: a Renovate Talos/k8s bump edits the `TalosUpgrade`/`KubernetesUpgrade` CR (which renders and matches), and the machineconfig itself is `mise`/`talosctl`-driven — never a Renovate PR.
- **CRDs** are the one accepted gap: `flate --skip-crds` (default) strips them from both kustomize- and Helm-sourced output since flate #182. Recoverable (Git revert); closing it means `--skip-crds=false`, which floods every human-facing flate comment with OpenAPI schemas and risks truncating the curator's own `diff.md`. Not worth it for recoverable risk.

## Files

- `policy.yaml` — `exclude_paths` removed; single `exclude_rendered` deny-list.
- `pr-curator.yaml` — Policy gate drops the `files=` extraction + path exclusion; order is now `flate → labels → rendered → eligible-type`.
- `README.md` — new "Gate on the render, not paths" section; trust-model prose unchanged in this PR.