### PR TITLE
feat(litellm): route claude-sonnet-5 to real copilot upstream

### DIFF
--- a/kubernetes/apps/default/litellm/resources/helm-release.yaml
+++ b/kubernetes/apps/default/litellm/resources/helm-release.yaml
@@ -57,7 +57,7 @@ spec:
         - { model_name: claude-opus-4-6-1m,        litellm_params: { model: github_copilot/claude-opus-4.6 },   model_info: *z }
         - { model_name: claude-sonnet-4-6,         litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
         - { model_name: claude-sonnet-4-5,         litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
-        - { model_name: claude-sonnet-5,           litellm_params: { model: github_copilot/claude-sonnet-4.6 }, model_info: *z }
+        - { model_name: claude-sonnet-5,           litellm_params: { model: github_copilot/claude-sonnet-5 },   model_info: *z }
         - { model_name: claude-haiku-4-5,          litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
         - { model_name: claude-haiku-4-5-20251001, litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
         - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }


### PR DESCRIPTION
## What

Repoint the `claude-sonnet-5` model alias from its `claude-sonnet-4.6` placeholder to the real `github_copilot/claude-sonnet-5` upstream.

## Why

Sonnet 5 just became available on the Copilot subscription. The alias already existed but was stubbed onto 4.6 so clients wouldn't 404 while the real model was unavailable. Now that Copilot serves it, route it through.

The upstream slug was **verified against the live Copilot backend** (`api.business.githubcopilot.com/models`) — it's `claude-sonnet-5` with no minor version.

## Scope

One line. Deliberately unchanged: `default` stays on opus-4.8, `default_fallbacks` stays on `claude-sonnet-4-6` (conservative while Sonnet 5 is fresh on Copilot's backend), and the `claude-sonnet-4-5` legacy alias stays mapped to 4.6.

## Verify post-merge

After Flux reconciles (reloader rolls the pod on the config-secret change), a call with `"model":"claude-sonnet-5"` should 200 rather than return `The requested model is not supported`.