### PR TITLE
feat(litellm): default to sonnet 5 + claude-code shortcut aliases

### DIFF
--- a/kubernetes/apps/default/litellm/resources/helm-release.yaml
+++ b/kubernetes/apps/default/litellm/resources/helm-release.yaml
@@ -50,7 +50,10 @@ spec:
       # prettier-ignore
       model_list:
         - { model_name: github_copilot/*,          litellm_params: { model: github_copilot/* },                 model_info: &z { cache_read_input_token_cost: 0, cache_creation_input_token_cost: 0 } }
-        - { model_name: default,                   litellm_params: { model: github_copilot/claude-opus-4.8 },   model_info: *z }
+        - { model_name: default,                   litellm_params: { model: github_copilot/claude-sonnet-5 },   model_info: *z }
+        - { model_name: sonnet,                    litellm_params: { model: github_copilot/claude-sonnet-5 },   model_info: *z }
+        - { model_name: opus,                      litellm_params: { model: github_copilot/claude-opus-4.8 },   model_info: *z }
+        - { model_name: haiku,                     litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
         - { model_name: claude-opus-4-8,           litellm_params: { model: github_copilot/claude-opus-4.8 },   model_info: *z }
         - { model_name: claude-opus-4-7,           litellm_params: { model: github_copilot/claude-opus-4.7 },   model_info: *z }
         - { model_name: claude-opus-4-6,           litellm_params: { model: github_copilot/claude-opus-4.6 },   model_info: *z }
@@ -67,7 +70,7 @@ spec:
 
       router_settings:
         default_fallbacks:
-          - claude-sonnet-4-6
+          - claude-sonnet-5
     volumes:
       - name: litellm-cache
         persistentVolumeClaim:


### PR DESCRIPTION
## What

Make the LiteLLM proxy's model experience mirror Claude Code, now that Sonnet 5 is live on the Copilot backend:

- `default` alias → `github_copilot/claude-sonnet-5` (was opus-4.8) — Sonnet as the daily-driver default, matching Claude Code.
- Add bare shortcut aliases mirroring Claude Code's `/model` picker: `sonnet`→sonnet-5, `opus`→opus-4.8, `haiku`→haiku-4.5.
- Bump `router_settings.default_fallbacks` from `claude-sonnet-4-6` to `claude-sonnet-5`.

Opus stays fully reachable via `claude-opus-4-8` / `opus`. Versioned aliases and haiku background routing unchanged.

## Why

Sonnet is Claude Code's out-of-the-box workhorse; Opus is reserved for heavy tasks. This aligns the proxy's default + shortcut names with that experience instead of defaulting to Opus.

## Scope

Single file: `kubernetes/apps/default/litellm/resources/helm-release.yaml`. All alias routing lives here — the curator workflow only sends `curator-model`, and clients reach the proxy via `vars.LITELLM_BASE_URL`, so nothing else needs touching.

## Verify post-merge

After Flux reconciles (reloader rolls the pod), calls with `"model":"default"`, `"sonnet"`, `"opus"`, `"haiku"` should each 200 and report the expected upstream.