### PR TITLE
fix(litellm): route curator-model to Haiku per pr-curator plan

### DIFF
--- a/.github/curator/README.md
+++ b/.github/curator/README.md
@@ -144,7 +144,7 @@ must pass the required checks. The load-bearing controls:
 ## Infrastructure
 
 - **LiteLLM** in-cluster (`kubernetes/apps/default/litellm/`). `curator-model`
-  alias routes to the cheap tier (Copilot `gpt-4o-mini`). Same alias for both
+  alias routes to the cheap tier (Copilot `claude-haiku-4.5`). Same alias for both
   summarise and classify. Both calls are bounded: `temperature: 0`,
   `response_format`-pinned JSON, and a `max_tokens` cap (summarise 2048, classify 512) — a truncated response fails schema validation and routes to `needs-human`.
 - **External access:** second HTTPRoute `litellm.mcf.io` on the `external`

--- a/kubernetes/apps/default/litellm/resources/helm-release.yaml
+++ b/kubernetes/apps/default/litellm/resources/helm-release.yaml
@@ -66,7 +66,7 @@ spec:
         - { model_name: claude-3-5-haiku-20241022, litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
         - { model_name: claude-3-5-haiku-latest,   litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
         - { model_name: claude-3-haiku-20240307,   litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
-        - { model_name: curator-model,             litellm_params: { model: github_copilot/gpt-4o-mini },       model_info: *z }
+        - { model_name: curator-model,             litellm_params: { model: github_copilot/claude-haiku-4.5 },  model_info: *z }
 
       router_settings:
         default_fallbacks:


### PR DESCRIPTION
## Summary
- `curator-model` in the LiteLLM HelmRelease routed to Copilot `gpt-4o-mini`, but `.claude/plans/pr-curator-litellm.md` decided on Haiku as the backend — corrects the drift.
- Updates `.github/curator/README.md` to match.

## Test plan
- [ ] `flate diff` / CI passes
- [ ] Merge, let Flux reconcile the HelmRelease, confirm `curator-model` alias resolves to `claude-haiku-4.5` in LiteLLM