### PR TITLE
fix(ci): correctly extract JSON from curator LLM responses with trailing prose

### DIFF
--- a/.github/workflows/pr-curator.yaml
+++ b/.github/workflows/pr-curator.yaml
@@ -260,7 +260,7 @@ jobs:
 
           echo "$resp" | jq -e '
             .choices[0].message.content
-            | gsub("^```json\\s*";"") | gsub("```\\s*$";"")
+            | (capture("```json\\s*(?<j>.*?)\\s*```"; "m").j // .)
             | fromjson
             | select(.packages | type == "array")
           ' > curator/changelog-summary.json
@@ -317,7 +317,7 @@ jobs:
 
           echo "$resp" | jq -e '
             .choices[0].message.content
-            | gsub("^```json\\s*";"") | gsub("```\\s*$";"")
+            | (capture("```json\\s*(?<j>.*?)\\s*```"; "m").j // .)
             | fromjson
             | select(.verdict and .rationale)
             | select(.verdict == "safe" or .verdict == "needs-human")


### PR DESCRIPTION
## Summary
- The PR Curator's `Classify` and `Summarise changelogs` steps parse the LiteLLM chat completion response by stripping a leading ` ```json ` fence and a trailing ` ``` ` fence anchored to the start/end of the string.
- `curator-model` (`github_copilot/claude-haiku-4.5` via LiteLLM) occasionally ignores `response_format: json_schema strict:true` and appends prose after the closing fence (e.g. a `**Reasoning:**` section). The anchored `gsub` doesn't match in that case, so `fromjson` fails on the leftover markdown.
- Confirmed as the cause of 4 CI failures: runs #135, #138, #140, #181.
- Replaced the anchor-strip with `capture("```json\s*(?<j>.*?)\s*```"; "m").j // .`, which extracts just the fenced block regardless of trailing content, falling back to the raw string when unfenced. Verified against the actual run #181 payload and a clean unfenced case.

## Test plan
- [x] Reproduced the exact failure payload from run #181 locally with `jq` and confirmed the old filter fails / new filter succeeds
- [x] Confirmed the fix also handles the unfenced (already-clean) response shape
- [ ] Watch the next few live curator runs for a clean pass on a PR that previously would have tripped this