### PR TITLE
fix(rook-ceph): rotate CephX keys for CVE-2025-30156

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/resources/helm-release.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/resources/helm-release.yaml
@@ -26,6 +26,23 @@ spec:
           - name: internal
             namespace: ingress-system
     cephClusterSpec:
+      # rotation due to CVE-2025-30156 an authentication bypass in CephX implementation
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+          csi:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+            # this remains until kernel 7.0+
+            keepPriorKeyCountMax: 1
+            keyType: aes
+          rbdMirrorPeer:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+            # this remains until kernel 7.0+
+            keyType: aes
       cephConfig:
         global:
           bdev_enable_discard: "true"
@@ -46,24 +63,12 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
-          - name: rook
-            enabled: true
           - name: diskprediction_local
             enabled: true
       network:
         provider: host
         connections:
           requireMsgr2: true
-      placement:
-        all:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/arch
-                      operator: NotIn
-                      values:
-                        - arm64
       resources:
         mgr:
           requests:
@@ -111,14 +116,22 @@ spec:
           mountOptions:
             - discard
           parameters:
+            compression_algorithm: zstd
+            compression_mode: aggressive
             imageFormat: "2"
             imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
             csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
             csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
             csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
             csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
             csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
             csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-modify-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-modify-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/node-publish-secret-name: rook-csi-rbd-node
+            csi.storage.k8s.io/node-publish-secret-namespace: "{{ .Release.Namespace }}"
             csi.storage.k8s.io/fstype: ext4
     cephBlockPoolsVolumeSnapshotClass:
       enabled: true


### PR DESCRIPTION
## Summary

CVE-2025-30156 is a CephX authentication bypass: legacy AES-based service tickets don't carry integrity checks, so anyone holding a CephX key can bit-flip a ticket's permissions undetected and escalate to admin. It affects every Ceph/Rook cluster. Rook v1.20.5 (already running here since #3657) carries the fix, but it requires an explicit key rotation — upgrading alone doesn't touch keys already issued.

This follows Rook's own resolution guide and sets `security.cephx` on the CephCluster spec:

- `daemon`: `keyRotationPolicy: KeyGeneration`, `keyGeneration: 2` — rotates mon/mgr/OSD/MDS keys, letting Rook pick the best key type per daemon (AES256K where supported).
- `csi` and `rbdMirrorPeer`: same rotation trigger, but pinned to `keyType: aes` rather than the newer `aes256k`, since AES256K kernel mounts need Linux 7.0+ and these nodes aren't there yet. `csi` also sets `keepPriorKeyCountMax: 1` so PVC mounts already in flight survive the rotation.

Also folded in a few small pending tweaks to the same file while I was in there — not CVE-related: dropped the unused `rook` mgr module, dropped a dead arm64 `nodeAffinity` exclusion (this cluster is Intel N150 only, so it never matched anything), added zstd compression to the `ceph-replicated` storage class, and rounded out the CSI secret parameters with the missing publish/modify entries.

## What to expect

Ceph health warnings during and just after rotation are normal — old tickets stay valid for a couple of hours while things settle. `AUTH_INSECURE_*` errors on daemons should clear once rotation finishes; warnings for CSI/mirror-peer clients will likely stick around until the kernel reaches 7.0+, which is expected.

## Test plan

- [ ] `flate diff` renders clean for the rook-ceph-cluster Kustomization
- [ ] After Flux reconciles, `kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.cephx}'` shows daemon key generation at 2
- [ ] `ceph health detail` via the toolbox pod shows no lingering `AUTH_INSECURE_*` errors for core daemons