### PR TITLE
feat(kopiur): pilot VolSync to kopiur migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Recognizing constraints is an important step in sustainable design and as such d
 - **OS:** Talos Linux on bare metal, declared via templated machine configs in `talos/`.
 - **Hardware:** GMKtec G3+ mini PCs (Intel N150, 32GB RAM), NVMe drives partitioned for etcd + Ceph fast pool.
 - **Networking:** Cilium for CNI, Envoy Gateway for north-south ingress.
-- **Storage:** Rook-Ceph for block, OpenEBS for local volumes, VolSync for backup orchestration. mergerfs+nfs-server for bulk media on a single node.
+- **Storage:** Rook-Ceph for block, OpenEBS for local volumes, kopiur for backup orchestration (migrating from VolSync). mergerfs+nfs-server for bulk media on a single node.
 - **Databases:** CloudNativePG for Postgres workloads.
 - **Secrets:** External Secrets Operator pulling from an external store.
 - **Certificates:** cert-manager with external-dns wiring DNS challenges.

--- a/kubernetes/.mise.toml
+++ b/kubernetes/.mise.toml
@@ -40,6 +40,30 @@ flux -n volsync-system ${usage_state} helmrelease volsync
 kubectl --namespace volsync-system scale deployment volsync --replicas ${replicas:-0}
 '''
 
+[tasks.kopiur-snapshot]
+description = "Trigger an out-of-band snapshot for every kopiur SnapshotPolicy via the kubectl-kopiur plugin."
+quiet = true
+run = '''
+kubectl get snapshotpolicies --no-headers --all-namespaces | while read -r namespace name _; do
+  kubectl kopiur snapshot now --namespace "${namespace}" "${name}"
+done
+'''
+
+[tasks.kopiur]
+description = "Suspend or resume kopiur by scaling the deployment and suspending/resuming the Kustomization and HelmRelease."
+quiet = true
+usage = '''
+arg "<state>" {
+  choices "suspend" "resume"
+}
+'''
+run = '''
+[[ "${usage_state}" == "resume" ]]; replicas=1
+flux -n kopiur-system ${usage_state} kustomization kopiur
+flux -n kopiur-system ${usage_state} helmrelease kopiur
+kubectl --namespace kopiur-system scale deployment kopiur --replicas ${replicas:-0}
+'''
+
 [tasks.sync-es]
 description = "Trigger reconciliation of ExternalSecrets by updating the force-sync annotation with the current timestamp."
 quiet = true

--- a/kubernetes/apps/default/tautulli/flux-kustomization.yaml
+++ b/kubernetes/apps/default/tautulli/flux-kustomization.yaml
@@ -6,8 +6,10 @@ metadata:
   name: &appname tautulli
 spec:
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur
+      namespace: kopiur-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   interval: 12h
   path: ./kubernetes/apps/default/tautulli/resources
   prune: true
@@ -18,10 +20,9 @@ spec:
   targetNamespace: default
   wait: false
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   postBuild:
     substitute:
       app: *appname
       volume_name: tautulli-config
       volume_capacity: 2Gi
-      volume_cache_capacity: 4Gi

--- a/kubernetes/apps/kopiur-system/kopiur/flux-kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/flux-kustomization.yaml
@@ -3,26 +3,22 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: recyclarr
+  name: kopiur
 spec:
   dependsOn:
-    - name: external-secrets
-      namespace: external-secrets
-    - name: kopiur
+    - name: snapshot-controller
+      namespace: kube-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kopiur
       namespace: kopiur-system
-    - name: kopiur-repository
-      namespace: kopiur-system
-  components:
-    - ../../../../components/kopiur/backup
   interval: 12h
-  path: ./kubernetes/apps/default/recyclarr/resources
+  path: ./kubernetes/apps/kopiur-system/kopiur/resources
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: default
-  wait: false
-  postBuild:
-    substitute:
-      app: recyclarr
+  targetNamespace: kopiur-system
+  wait: true

--- a/kubernetes/apps/kopiur-system/kopiur/resources/helm-release.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/resources/helm-release.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  interval: 12h
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  values:
+    # cluster scope is required for a single shared ClusterRepository (namespaced
+    # scope cannot reconcile ClusterRepository at all).
+    installScope: cluster

--- a/kubernetes/apps/kopiur-system/kopiur/resources/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/resources/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/resources/oci-repository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/resources/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/home-operations/charts/kopiur
+  ref:
+    tag: 0.10.3

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+components:
+  - ../../components/alerts
+  - ../../components/kopiur/secret
+resources:
+  - ./namespace.yaml
+  - ./kopiur/flux-kustomization.yaml
+  - ./repository/flux-kustomization.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: not-used
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/kopiur-system/repository/flux-kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/repository/flux-kustomization.yaml
@@ -3,26 +3,16 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: recyclarr
+  name: kopiur-repository
 spec:
   dependsOn:
-    - name: external-secrets
-      namespace: external-secrets
     - name: kopiur
-      namespace: kopiur-system
-    - name: kopiur-repository
-      namespace: kopiur-system
-  components:
-    - ../../../../components/kopiur/backup
   interval: 12h
-  path: ./kubernetes/apps/default/recyclarr/resources
+  path: ./kubernetes/apps/kopiur-system/repository/resources
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: default
+  targetNamespace: kopiur-system
   wait: false
-  postBuild:
-    substitute:
-      app: recyclarr

--- a/kubernetes/apps/kopiur-system/repository/resources/cluster-repository.yaml
+++ b/kubernetes/apps/kopiur-system/repository/resources/cluster-repository.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: archive
+spec:
+  # Shared by every app namespace today, same as the single physical repo VolSync
+  # already writes into - no reason to fragment into per-namespace Repository objects.
+  allowedNamespaces:
+    all: true
+  backend:
+    filesystem:
+      # VERIFY before first apply: this must resolve to the SAME on-disk directory
+      # VolSync/kopia already use (NFS 10.46.100.100:/archive/kopia, i.e. the "kopia"
+      # subdirectory of the /archive export - not the export root). Confirm the
+      # path/volume.nfs.path split against `kubectl explain clusterrepository.spec.backend.filesystem
+      # --recursive` before pointing this at production data: getting this wrong either
+      # points at an empty directory (loses "true adoption") or, worse, a sibling path.
+      path: /repo
+      volume:
+        nfs:
+          server: 10.46.100.100 # Use IP instead of nfs-server.default.svc.cluster.local
+          path: /archive/kopia
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository
+      key: KOPIA_PASSWORD
+  create:
+    enabled: false # adopting the existing repository, never reinitialize it

--- a/kubernetes/apps/kopiur-system/repository/resources/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/repository/resources/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster-repository.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetes.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetes.yaml
@@ -13,6 +13,11 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    # Verify status.phase against the live CRD before trusting this gate in a real upgrade.
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
+      expr: |-
+        status.phase != 'Running'
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
       expr: |-

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
@@ -15,6 +15,11 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    # Verify status.phase against the live CRD before trusting this gate in a real upgrade.
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
+      expr: |-
+        status.phase != 'Running'
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
       expr: |-

--- a/kubernetes/components/kopiur/backup/kustomization.yaml
+++ b/kubernetes/components/kopiur/backup/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/component.json
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml
+  - ./restore.yaml
+  - ./pvc.yaml

--- a/kubernetes/components/kopiur/backup/pvc.yaml
+++ b/kubernetes/components/kopiur/backup/pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${volume_name:=${app}}
+spec:
+  accessModes:
+    - ${volume_accessmodes:=ReadWriteOnce}
+  dataSourceRef:
+    kind: Restore
+    apiGroup: kopiur.home-operations.com
+    name: ${app}
+  resources:
+    requests:
+      storage: ${volume_capacity:=1Gi}
+  storageClassName: ${volume_storageclass:=ceph-replicated}

--- a/kubernetes/components/kopiur/backup/restore.yaml
+++ b/kubernetes/components/kopiur/backup/restore.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: ${app}
+spec:
+  source:
+    fromPolicy:
+      name: ${app}
+      offset: 0 # latest snapshot
+  # Passive populator mode: no target at provision time - the PVC below claims this
+  # Restore via its own dataSourceRef.
+  target:
+    populator: {}
+  policy:
+    # Empty-volume bootstrap on first-ever apply (no prior snapshot yet), same as
+    # VolSync's restore-once pattern today.
+    onMissingSnapshot: Continue

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${app}
+spec:
+  repository:
+    kind: ClusterRepository
+    name: archive
+  sources:
+    - pvc:
+        name: ${volume_name:=${app}}
+  copyMethod: Snapshot
+  volumeSnapshotClassName: ${volume_snapshotclass:=csi-ceph-blockpool}
+  compression:
+    compressor: zstd-fastest
+  # GFS retention is the only successful-retention driver - matches current VolSync retain values.
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+  mover:
+    securityContext:
+      runAsUser: ${volume_uid:=1000}
+      runAsGroup: ${volume_gid:=1000}
+      fsGroup: ${volume_gid:=1000}

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: ${app}
+spec:
+  policyRef:
+    name: ${app}
+  schedule:
+    cron: 0 */8 * * *
+    jitter: ${volume_jitter:=5m}
+    # GitOps-friendly: don't fire a backup the moment the Kustomization first applies.
+    runOnCreate: false

--- a/kubernetes/components/kopiur/secret/external-secret.yaml
+++ b/kubernetes/components/kopiur/secret/external-secret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-repository
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: kopiur-repository
+    creationPolicy: Owner
+    template:
+      data:
+        KOPIA_PASSWORD: "{{ .credential }}"
+  data:
+    - secretKey: credential
+      remoteRef:
+        key: KOPIA_PASSWORD

--- a/kubernetes/components/kopiur/secret/kustomization.yaml
+++ b/kubernetes/components/kopiur/secret/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/component.json
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./external-secret.yaml


### PR DESCRIPTION
## Summary

Introduces kopiur as a replacement for VolSync, piloted on two low-stakes apps before
touching the rest. Adds the kopiur operator (`kubernetes/apps/kopiur-system/`) and a single
`ClusterRepository` pointed at the existing Kopia NFS repo. Because the current VolSync mover
is already the Kopia fork, this is in-place adoption of the same repository, not a fresh one —
snapshot history carries forward.

recyclarr and tautulli are cut over to a new two-part Kustomize component
(`kubernetes/components/kopiur/`, secret + backup) replacing `components/volsync` for those
two apps only. VolSync and the other 12 apps are untouched. tuppr's upgrade healthChecks and
the `.mise.toml` snapshot/suspend tasks are updated to target kopiur's CRDs alongside VolSync's.

Remaining apps and the VolSync teardown follow once the pilot has a verified restore
round-trip.

## Test plan

- [x] `flate diff` clean on every touched Kustomization
- [ ] kopiur controller and `ClusterRepository` reconcile healthy post-merge
- [ ] `kubectl kopiur migrate volsync --strict --dry-run` report reviewed for recyclarr and tautulli
- [ ] Snapshot history is continuous across the cutover (no fresh-repo reset)
- [ ] Forced snapshot completes for both apps
- [ ] Restore round-trip verified: scale to 0, delete PVC, confirm repopulation, scale back up