### PR TITLE
fix(kopiur): switch snapshot retention to keepLatest

### DIFF
--- a/kubernetes/apps/default/zwave/resources/snapshotpolicy.yaml
+++ b/kubernetes/apps/default/zwave/resources/snapshotpolicy.yaml
@@ -23,8 +23,7 @@ spec:
   upload:
     maxParallelFileReads: ${volume_parallelism:=2}
   retention:
-    keepHourly: 24
-    keepDaily: 7
+    keepLatest: 45 # ~2 weeks at the current 3-snapshots/day schedule
   mover:
     # zwave runs privileged as root with no pinned UID; the session-secret file is root-only.
     podSecurityContext:

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -23,8 +23,7 @@ spec:
   upload:
     maxParallelFileReads: ${volume_parallelism:=2}
   retention:
-    keepHourly: 24
-    keepDaily: 7
+    keepLatest: 45 # ~2 weeks at the current 3-snapshots/day schedule
   mover:
     inheritSecurityContextFrom:
       pvcConsumer: {} # derive mover UID/GID from the workload mounting the PVC


### PR DESCRIPTION
## Summary

- Replaces `keepHourly: 24` / `keepDaily: 7` with `keepLatest: 45` on the shared `SnapshotPolicy` component and zwave's standalone copy.
- `keepHourly`/`keepDaily` bucket by calendar period, not elapsed time, so they don't cleanly express "restore from any snapshot in the last week or two" — the actual use case here is recovering a corrupted PVC, not browsing history.
- `keepLatest` is a flat count with no bucketing, so `keepLatest: 45` gives a straightforward ~2-week window at the current 3-snapshots/day schedule.

## Test plan

- [x] `flate build ks recyclarr` / `flate build ks zwave` show `retention.keepLatest: 45` with no leftover `keepHourly`/`keepDaily`
- [x] `flate diff ks recyclarr` / `flate diff ks zwave` show a clean two-field-removed/one-field-added swap on `spec.retention`, nothing else changed
- [x] `kubectl apply --dry-run=server` against the rendered recyclarr `SnapshotPolicy` succeeds
- [ ] Confirm live `SnapshotPolicy` objects reflect `keepLatest: 45` post-merge