### PR TITLE
fix(kopiur): move shared repository into default as a namespaced Repository

### DIFF
--- a/kubernetes/apps/default/home-assistant/flux-kustomization.yaml
+++ b/kubernetes/apps/default/home-assistant/flux-kustomization.yaml
@@ -10,7 +10,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/home-assistant/resources
   prune: true

--- a/kubernetes/apps/default/kopiur-repository/flux-kustomization.yaml
+++ b/kubernetes/apps/default/kopiur-repository/flux-kustomization.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   dependsOn:
     - name: kopiur
+      namespace: kopiur-system
   interval: 12h
-  path: ./kubernetes/apps/kopiur-system/repository/resources
+  path: ./kubernetes/apps/default/kopiur-repository/resources
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: kopiur-system
+  targetNamespace: default
   wait: false

--- a/kubernetes/apps/default/kopiur-repository/resources/kustomization.yaml
+++ b/kubernetes/apps/default/kopiur-repository/resources/kustomization.yaml
@@ -3,4 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./cluster-repository.yaml
+  - ./repository.yaml

--- a/kubernetes/apps/default/kopiur-repository/resources/repository.yaml
+++ b/kubernetes/apps/default/kopiur-repository/resources/repository.yaml
@@ -1,12 +1,10 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repository_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1
-kind: ClusterRepository
+kind: Repository
 metadata:
   name: archive
 spec:
-  allowedNamespaces:
-    all: true # single physical repo, shared by every app namespace, same as VolSync today
   backend:
     filesystem:
       path: /repo
@@ -18,6 +16,5 @@ spec:
     passwordSecretRef:
       name: kopiur-repository
       key: KOPIA_PASSWORD
-      namespace: kopiur-system # required explicitly for browse sessions to resolve it
   create:
     enabled: false # adopting the existing repository, never reinitialize it

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -11,6 +11,7 @@ components:
   - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
+  - ./kopiur-repository/flux-kustomization.yaml
   - ./sonarr/flux-kustomization.yaml
   - ./radarr/flux-kustomization.yaml
   - ./listenarr/flux-kustomization.yaml

--- a/kubernetes/apps/default/listenarr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/listenarr/flux-kustomization.yaml
@@ -10,7 +10,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/listenarr/resources
   prune: true

--- a/kubernetes/apps/default/maintainerr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/maintainerr/flux-kustomization.yaml
@@ -9,7 +9,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/maintainerr/resources
   prune: true

--- a/kubernetes/apps/default/matter-server/flux-kustomization.yaml
+++ b/kubernetes/apps/default/matter-server/flux-kustomization.yaml
@@ -9,7 +9,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/matter-server/resources
   prune: true

--- a/kubernetes/apps/default/plex/flux-kustomization.yaml
+++ b/kubernetes/apps/default/plex/flux-kustomization.yaml
@@ -10,7 +10,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/plex/resources
   prune: true

--- a/kubernetes/apps/default/prowlarr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/prowlarr/flux-kustomization.yaml
@@ -11,7 +11,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/prowlarr/resources
   prune: true

--- a/kubernetes/apps/default/radarr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/radarr/flux-kustomization.yaml
@@ -12,7 +12,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/radarr/resources
   prune: true

--- a/kubernetes/apps/default/recyclarr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/recyclarr/flux-kustomization.yaml
@@ -11,7 +11,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   components:
     - ../../../../components/kopiur/backup
   interval: 12h

--- a/kubernetes/apps/default/sabnzbd/flux-kustomization.yaml
+++ b/kubernetes/apps/default/sabnzbd/flux-kustomization.yaml
@@ -10,7 +10,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/sabnzbd/resources
   prune: true

--- a/kubernetes/apps/default/scrypted/flux-kustomization.yaml
+++ b/kubernetes/apps/default/scrypted/flux-kustomization.yaml
@@ -9,7 +9,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/scrypted/resources
   prune: true

--- a/kubernetes/apps/default/seerr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/seerr/flux-kustomization.yaml
@@ -9,7 +9,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/seerr/resources
   prune: true

--- a/kubernetes/apps/default/sonarr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/sonarr/flux-kustomization.yaml
@@ -12,7 +12,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/sonarr/resources
   prune: true

--- a/kubernetes/apps/default/tautulli/flux-kustomization.yaml
+++ b/kubernetes/apps/default/tautulli/flux-kustomization.yaml
@@ -9,7 +9,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/tautulli/resources
   prune: true

--- a/kubernetes/apps/default/zwave/flux-kustomization.yaml
+++ b/kubernetes/apps/default/zwave/flux-kustomization.yaml
@@ -11,7 +11,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
     - name: kopiur-repository
-      namespace: kopiur-system
+      namespace: default
   interval: 12h
   path: ./kubernetes/apps/default/zwave/resources
   prune: true

--- a/kubernetes/apps/default/zwave/resources/snapshotpolicy.yaml
+++ b/kubernetes/apps/default/zwave/resources/snapshotpolicy.yaml
@@ -6,7 +6,6 @@ metadata:
   name: ${app}
 spec:
   repository:
-    kind: ClusterRepository
     name: archive
   # Pins the existing snapshot identity so kopiur continues the adopted history.
   identity:

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 namespace: kopiur-system
 components:
   - ../../components/alerts
-  - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
   - ./kopiur/flux-kustomization.yaml
-  - ./repository/flux-kustomization.yaml

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -6,7 +6,6 @@ metadata:
   name: ${app}
 spec:
   repository:
-    kind: ClusterRepository
     name: archive
   # Pins the existing snapshot identity so kopiur continues the adopted history.
   identity:


### PR DESCRIPTION
## Summary

Every app kopiur backs up lives in `default`, so the cluster-scoped `ClusterRepository` was buying nothing except cross-namespace Secret plumbing. That plumbing is also why `kubectl kopiur ls`/`browse` didn't work: the browse session pod runs in the workload's namespace and can't load a Secret from `kopiur-system`, and `credentialProjection` (the field that's supposed to help here) isn't wired into the browse CLI path at all. Confirmed against kopiur's source and its issue tracker, not guessed.

A namespaced `Repository` living in `default` sidesteps this entirely — repo and Secret co-reside by construction, which is exactly what kopiur's own docs recommend for a single-tenant setup like this one. Same physical NFS-backed repo, same Kopia password (already replicated into `default` for mover `envFrom`). No data migration, just swapping which object all 14 apps point at.

Changes:
- New `kubernetes/apps/default/kopiur-repository/` (Flux Kustomization + `Repository` CR), replacing `kubernetes/apps/kopiur-system/repository/` (deleted).
- `kopiur/backup` component and zwave's standalone `SnapshotPolicy` drop `kind: ClusterRepository` (defaults to `Repository`) and point at the new object.
- All 14 apps' `flux-kustomization.yaml` `dependsOn` for `kopiur-repository` moves from `kopiur-system` to `default`.
- Removed the now-unused `kopiur/secret` component from `kopiur-system`'s own kustomization — nothing there needs the password anymore.

## Test plan

- [x] `flate diff all --base origin/main` — clean swap, all 14 `SnapshotPolicy.spec.repository` changes render, no blocked/dangling `dependsOn`
- [ ] `Repository/default/archive` reaches `Ready` post-merge
- [ ] Force a snapshot on one app, confirm it completes against the new `Repository`
- [ ] `kubectl kopiur ls` works without the cross-namespace credential error
- [ ] `ClusterRepository/kopiur-system/archive` is gone after prune