### PR TITLE
fix(matter-server): move IPv6 RA sysctl off pod spec onto the CNI chain

### DIFF
--- a/docs/agent-notes.md
+++ b/docs/agent-notes.md
@@ -149,6 +149,19 @@ located from a browse session`. Fix: pin `namespace: kopiur-system` (or wherever
   around by job history still counts. `kubectl delete pvc` hangs in `Terminating` with no events;
   `kubectl delete job <the-old-job>` (which owns the pod) unblocks it immediately. Verified during
   a real restore-round-trip test on `recyclarr` (a CronJob-backed app).
+- **`mover.inheritSecurityContextFrom.pvcConsumer` copies the whole `PodSecurityContext`, not just
+  UID/GID.** Confirmed against a live cluster: `matter-server`'s mover Job pod inherited the
+  workload's pod-level `sysctls` entry (`net.ipv6.conf.net1.accept_ra_rt_info_max_plen`, meant for
+  its Multus macvlan `net1` interface) even though the mover pod itself carries no Multus network
+  annotation and never gets a `net1` at all. Every mover run then failed sandbox creation
+  permanently (`FailedCreatePodSandBox`, runc reporting the missing-interface sysctl write as
+  `"unsafe procfs detected"` rather than a plain ENOENT — a hardened-procfs-openat2 message shape,
+  not a permissions issue). Any app-level pod sysctl that targets a secondary-CNI interface will
+  break that app's kopiur backups this way. Fix: never put interface-scoped sysctls on
+  `defaultPodOptions.securityContext.sysctls` for a pod with a Multus attachment — put them on the
+  `NetworkAttachmentDefinition` instead, via a `tuning` CNI meta-plugin stage chained after the
+  interface-creating plugin (e.g. `macvlan` → `sbr` → `tuning`). The `tuning` plugin binary ships in
+  the same `cni-plugins` bundle already providing `sbr`.
 
 ## Git / PR workflow gotchas (verified, not guessed)
 

--- a/kubernetes/apps/default/matter-server/resources/helm-release.yaml
+++ b/kubernetes/apps/default/matter-server/resources/helm-release.yaml
@@ -53,9 +53,6 @@ spec:
         runAsGroup: 568
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
-        sysctls:
-          - name: net.ipv6.conf.net1.accept_ra_rt_info_max_plen
-            value: "64"
     service:
       app:
         ports:

--- a/kubernetes/apps/kube-system/multus/networks/client-network.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/client-network.yaml
@@ -23,6 +23,12 @@ spec:
         },
         {
           "type": "sbr"
+        },
+        {
+          "type": "tuning",
+          "sysctl": {
+            "net.ipv6.conf.IFNAME.accept_ra_rt_info_max_plen": "64"
+          }
         }
       ]
     }

--- a/talos/cluster.yaml
+++ b/talos/cluster.yaml
@@ -50,8 +50,6 @@ machine:
       imageGCHighThresholdPercent: 70
       imageGCLowThresholdPercent: 50
       shutdownGracePeriod: 60s
-      allowedUnsafeSysctls:
-        - net.ipv6.conf.net1.accept_ra_rt_info_max_plen # Accept max plen for ipv6 thread border router advertisements
     image: ghcr.io/siderolabs/kubelet:v1.36.3
     nodeIP:
       validSubnets:


### PR DESCRIPTION
## Summary

- matter-server's kopiur backup job was stuck in `ContainerCreating` for 3+ hours, retrying every second with `FailedCreatePodSandBox: ... open sysctl net.ipv6.conf.net1.accept_ra_rt_info_max_plen file: unsafe procfs detected ...`.
- Root cause: matter-server's pod carries a pod-level sysctl for its Multus macvlan `net1` interface (needed for Matter/Thread border-router IPv6 RA handling). kopiur's `mover.inheritSecurityContextFrom.pvcConsumer` copies the whole `PodSecurityContext` onto the backup mover pod, not just UID/GID — but the mover pod has no Multus network annotation of its own, so it never gets a `net1` interface. runc then fails to write the sysctl for an interface that doesn't exist, and its hardened procfs-open path reports that as `"unsafe procfs detected"` instead of a plain missing-interface error. This is permanent, not a race — the mover pod can never satisfy it.
- Fix: moved the sysctl off the pod spec and onto the shared `client-network` NetworkAttachmentDefinition via a `tuning` CNI meta-plugin stage (`macvlan` → `sbr` → `tuning`). It applies the sysctl to `net1` only after macvlan creates it, and only on pods that actually request the network — kopiur's mover pod is unaffected. home-assistant and scrypted share `client-network` and pick up the same tuning for free.
- Removed the now-unneeded `allowedUnsafeSysctls` kubelet admission entry from `talos/cluster.yaml` — nothing in a pod spec declares this sysctl any more.
- Recorded the `inheritSecurityContextFrom` behaviour in `docs/agent-notes.md` so the next app with a secondary-interface sysctl doesn't hit the same wall.

## Test plan

- [x] `flate build ks matter-server` and `flate build ks multus-networks` render cleanly
- [x] Confirmed live on the cluster: mover pod's only interface was `eth0`/Cilium (no `net1`), and it carried the inherited `net.ipv6.conf.net1.*` sysctl — matches the theory
- [ ] After merge + Flux reconcile: confirm matter-server's Deployment pod still gets `net1` with the RA sysctl applied, and the next kopiur backup run for matter-server completes instead of looping on `FailedCreatePodSandBox`