### PR TITLE
fix(matter-server): move IPv6 RA sysctl to a dedicated NetworkAttachmentDefinition

### DIFF
--- a/kubernetes/apps/default/matter-server/resources/helm-release.yaml
+++ b/kubernetes/apps/default/matter-server/resources/helm-release.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: |
           [{
-            "name": "client-network",
+            "name": "matter-network",
             "namespace": "kube-system",
             "ips": ["192.168.10.22/24"],
             "mac": "2e:37:2e:6d:ab:4a"

--- a/kubernetes/apps/kube-system/multus/networks/kustomization.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./client-network.yaml
+  - ./matter-network.yaml

--- a/kubernetes/apps/kube-system/multus/networks/matter-network.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/matter-network.yaml
@@ -2,12 +2,12 @@
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
-  name: client-network
+  name: matter-network
 spec:
   config: |-
     {
       "cniVersion": "0.3.1",
-      "name": "client-network",
+      "name": "matter-network",
       "plugins": [
         {
           "type": "macvlan",
@@ -23,6 +23,12 @@ spec:
         },
         {
           "type": "sbr"
+        },
+        {
+          "type": "tuning",
+          "sysctl": {
+            "net.ipv6.conf.IFNAME.accept_ra_rt_info_max_plen": "64"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Follow-up to #3675, which fixed matter-server's kopiur backup job getting stuck in `ContainerCreating` by moving its IPv6 RA sysctl off the pod spec and onto the CNI chain via a `tuning` plugin stage.
- That fix folded the `tuning` stage into the *shared* `client-network` NetworkAttachmentDefinition (also used by `home-assistant` and `scrypted`), on the theory that all three sit on the same L2 and would pick it up harmlessly. Wrong call: the RA route-info tuning is specific to matter-server's Matter/Thread border-router role, and any future consumer of `client-network` would silently inherit it too.
- Created a dedicated `matter-network` NetworkAttachmentDefinition with the same macvlan/sbr config as `client-network` plus the `tuning` stage, and repointed matter-server's HelmRelease annotation at it (same IP/MAC, just a different NAD). Reverted `client-network` back to plain macvlan+sbr — its state before #3675, no change for `home-assistant`/`scrypted`.

## Test plan

- [x] `flate build ks multus-networks` renders both NADs correctly (`client-network` without tuning, `matter-network` with it)
- [x] `flate build ks matter-server` shows the HelmRelease annotation pointing at `matter-network`
- [ ] After merge + Flux reconcile: matter-server's new pod gets `net1` from `matter-network` with the sysctl still applied, and `home-assistant`/`scrypted` are unaffected