### PR TITLE
fix(kopiur): allow privileged movers for zwave in default

### DIFF
--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: not-used
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # zwave's SnapshotPolicy needs a root mover (inheritSecurityContextFrom.pvcConsumer
+    # picks up its privileged, uid-0 pod) — kopiur gates that per namespace.
+    kopiur.home-operations.com/privileged-movers: "true"


### PR DESCRIPTION
## Summary
zwave's `SnapshotPolicy` inherits its mover's security context from whatever pod is currently mounting its PVC (`mover.inheritSecurityContextFrom.pvcConsumer`) — that's the zwave-js-ui pod itself, which runs privileged/root because it needs raw access to the Z-Wave USB stick via a hostPath char device. kopiur treats any elevated mover (root, `privileged: true`, added capabilities, `runAsNonRoot: false`) as a per-namespace admin decision, not something a `SnapshotPolicy` can grant on its own — a tenant with access to a namespace could otherwise reuse the minted `kopiur-mover` ServiceAccount at that privilege.

`default` was never opted in, so zwave's snapshots have been stuck `Pending` since the kopiur cutover, with the controller logging `blocked on an out-of-band grant ... namespace default has not opted in`.

Fix is one annotation: `kopiur.home-operations.com/privileged-movers: "true"` on `kubernetes/apps/default/namespace.yaml`. (This repo's `namespace.yaml` files carry a `not-used` placeholder name that the folder's `kustomization.yaml` overwrites via its `namespace:` field, so this is the right file for a `default`-level annotation.) Worth saying plainly: this is a single-operator cluster, not multi-tenant, and `default` already runs zwave's own privileged container for the same USB access — so the extra blast radius from this opt-in is close to nothing here.

## Test plan
- [x] `flate diff all --base origin/main` — single clean diff, one map entry added to the `Namespace`'s annotations
- [ ] zwave's next scheduled (or a forced) snapshot completes instead of sitting `Pending`
- [ ] `kubectl get snapshot -n default` confirms the mover pod actually ran as uid 0