### PR TITLE
fix(recyclarr): drop kopiur backup, let the chart own the PVC

### DIFF
--- a/kubernetes/apps/default/recyclarr/flux-kustomization.yaml
+++ b/kubernetes/apps/default/recyclarr/flux-kustomization.yaml
@@ -8,12 +8,6 @@ spec:
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
-    - name: kopiur
-      namespace: kopiur-system
-    - name: kopiur-repository
-      namespace: default
-  components:
-    - ../../../../components/kopiur/backup
   interval: 12h
   path: ./kubernetes/apps/default/recyclarr/resources
   prune: true
@@ -23,6 +17,3 @@ spec:
     namespace: flux-system
   targetNamespace: default
   wait: false
-  postBuild:
-    substitute:
-      app: recyclarr

--- a/kubernetes/apps/default/recyclarr/resources/helm-release.yaml
+++ b/kubernetes/apps/default/recyclarr/resources/helm-release.yaml
@@ -54,7 +54,9 @@ spec:
           type: RuntimeDefault
     persistence:
       config:
-        existingClaim: "{{ .Release.Name }}"
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
       config-file:
         type: configMap
         name: "{{ .Release.Name }}-configmap"


### PR DESCRIPTION
## Summary
- Recyclarr's config PVC was going through kopiur — 8-hourly snapshots, 45-generation retention — even though it only holds a read-only ConfigMap overlay and a little state-tracking data. Nothing worth backing up.
- The data that's actually worth caching (TRaSH-Guides clone, CLI logs) already lands on the tmp emptyDir via `RECYCLARR_DATA_DIR`.
- Removed the `kopiur/backup` component and its dependsOn entries. The PVC is now a plain chart-managed volume (1Gi, RWO) instead of an existingClaim wired to the component.

One-time side effect: the old kopiur-managed PVC gets pruned and the HelmRelease provisions a fresh empty one. Recyclarr's state resets once — harmless, it's a daily sync job that regenerates everything from TRaSH-Guides.

## Test plan
- [x] `flate build ks recyclarr` — no SnapshotPolicy/SnapshotSchedule/Restore rendered, PVC is `type: persistentVolumeClaim`
- [x] `flate diff kustomization` — clean removal of the four kopiur-managed objects, no dangling dependency errors
- [ ] After merge: confirm the old PVC is pruned and the new one binds, and the next `@daily` recyclarr CronJob run completes normally