### PR TITLE
fix(kopiur): restore dataSourceRef on shared config PVC component

### DIFF
--- a/kubernetes/components/kopiur/backup/pvc.yaml
+++ b/kubernetes/components/kopiur/backup/pvc.yaml
@@ -4,7 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: ${volume_name:=${app}}
 spec:
-  # No dataSourceRef: every app here already has a live, bound PVC.
+  dataSourceRef:
+    kind: Restore
+    apiGroup: kopiur.home-operations.com
+    name: ${app}
   accessModes:
     - ${volume_accessmodes:=ReadWriteOnce}
   resources:


### PR DESCRIPTION
Adds `dataSourceRef` back to the shared kopiur backup PVC component (`kubernetes/components/kopiur/backup/pvc.yaml`), used by 12 apps' config volumes. It used to be there; the comment being removed here explains why someone stripped it ("No dataSourceRef: every app here already has a live, bound PVC").

## Why

All 12 apps' current config PVCs are legacy RBD images that predate kopiur. They were originally created via VolSync's `dataSourceRef: ReplicationDestination` (VolSync is fully gone from the cluster now), and they still carry that old RBD clone-parent relationship — which is why old snapshot/image entries stay permanently pinned in `rbd trash` and can't be purged.

kopiur's `Restore` populator provisions a plain, standalone PVC with no `dataSourceRef` of its own — a file-level kopia snapshot restore followed by a PV rebind, no CSI VolumeSnapshot or RBD clone involved. Recreating each app's PVC through the populator breaks the legacy clone chain and finally lets those pinned trash entries get purged.

## Why this stays unmerged for now

`dataSourceRef` is immutable on an existing PVC, so this can't apply live to any of the 12 already-bound PVCs — merging as-is would error on their next reconcile. Each app gets cut over manually first: suspend its Kustomization, guard-rail the old PV to `Retain`, delete the old PVC, apply this branch's PVC by hand to trigger the populator restore, verify, clean up. Once every app's live PVC already matches this diff, merging is a no-op confirmation, not a trigger.

`home-assistant` is already there — an unrelated Helm chart PVC-naming bug in #3680/#3681 deleted its config PVC by accident, and it got recovered by hand through kopiur's populator using this same mechanism. Its reconcile will be a clean no-op once this merges, same as the rest.

recyclarr used to be on this list but dropped its kopiur backup entirely in #3682 (chart now owns its config PVC directly) — out of scope here.

## Rollout

- [x] home-assistant (done, via incident recovery, not this PR's process)
- [ ] prowlarr
- [ ] listenarr
- [ ] maintainerr
- [ ] tautulli
- [ ] sabnzbd
- [ ] matter-server
- [ ] scrypted
- [ ] radarr
- [ ] sonarr
- [ ] seerr
- [ ] plex