### PR TITLE
fix(kopiur): grant mover SA get on base restores resource

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/resources/cluster-role-binding.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/resources/cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kopiur-mover-restores-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kopiur-mover-restores-read
+subjects:
+  - kind: ServiceAccount
+    name: kopiur-mover
+    namespace: default
+  - kind: ServiceAccount
+    name: kopiur-mover
+    namespace: kopiur-system

--- a/kubernetes/apps/kopiur-system/kopiur/resources/cluster-role.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/resources/cluster-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kopiur-mover-restores-read
+rules:
+  - apiGroups:
+      - kopiur.home-operations.com
+    resources:
+      - restores
+    verbs:
+      - get

--- a/kubernetes/apps/kopiur-system/kopiur/resources/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/resources/kustomization.yaml
@@ -5,3 +5,5 @@ kind: Kustomization
 resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
+  - ./cluster-role.yaml
+  - ./cluster-role-binding.yaml


### PR DESCRIPTION
## Summary

Every mover Job during this session's PVC migration logged a recurring warning:

```
status.resolved read failed error=... restores.kopiur.home-operations.com "plex" is forbidden:
User "system:serviceaccount:default:kopiur-mover" cannot get resource "restores" ...
```

Traced it in kopiur's source (`crates/mover/src/status.rs`): the mover's `status.resolved()`
does a plain GET on the base `Restore` object, to check whether a prior Job attempt already
pinned a resolved snapshot — so a retry reuses the same snapshot instead of re-resolving
"latest". The chart-generated RBAC (`deploy/rbac/mover-role.yaml` / `mover-clusterrole.yaml`,
marked generated, not for hand-editing) only grants `get`/`patch` on the `restores/status`
subresource, never on the base `restores` resource. The GET needs `get` on `restores`, so it
403s every time and is silently swallowed as best-effort.

No mover Job retried during the migration, so this never changed behaviour — "no prior pin"
and "fresh resolve" landed on the same snapshot, and all 12 restores completed correctly. It'd
only bite on an actual Job retry (crash/OOM/reschedule), where it'd silently re-resolve
"latest" instead of reusing the pinned snapshot from the failed attempt.

This is upstream and the chart's RBAC is generated, so not something to patch by hand in the
vendored files. Layering a local `ClusterRole`/`ClusterRoleBinding` on top instead, granting
`get` on the base `restores` resource to the two `kopiur-mover` ServiceAccounts (`default` and
`kopiur-system`). Added under `kubernetes/apps/kopiur-system/kopiur/resources/`, cluster-scoped
so it's unaffected by that Kustomization's `targetNamespace: kopiur-system`.

Not filing an upstream issue as part of this — separate follow-up, not blocking.

## Test plan

- [x] `flate build ks kopiur` renders the new `ClusterRole`/`ClusterRoleBinding` correctly
- [x] Applied directly to confirm the fix: `kubectl auth can-i get restores.kopiur.home-operations.com -n default --as=system:serviceaccount:default:kopiur-mover` → `yes` (was `no`/403 before)
- [ ] Flux reconcile picks up the same objects as a no-op once merged