### PR TITLE
Add DNS health checks and external-dns sync alerts

### DIFF
--- a/kubernetes/apps/default/gatus/resources/config/gatus.yaml
+++ b/kubernetes/apps/default/gatus/resources/config/gatus.yaml
@@ -24,6 +24,27 @@ connectivity:
     interval: 1m
 
 endpoints:
+  - name: internal-dns
+    group: dns
+    url: 192.168.10.1
+    interval: 60s
+    dns:
+      query-name: ipv4.milton.mcf.io
+      query-type: A
+    conditions:
+      - "[DNS_RCODE] == NOERROR"
+      - "[BODY] == 192.168.46.96"
+
+  - name: public-dns
+    group: dns
+    url: 9.9.9.9
+    interval: 120s
+    dns:
+      query-name: status.mcf.io
+      query-type: A
+    conditions:
+      - "[DNS_RCODE] == NOERROR"
+
   - name: Cloudflare
     group: connectivity
     url: icmp://1.1.1.1

--- a/kubernetes/apps/ingress-system/external-dns-cloudflare/resources/kustomization.yaml
+++ b/kubernetes/apps/ingress-system/external-dns-cloudflare/resources/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./external-secret.yaml
   - ./oci-repository.yaml
   - ./helm-release.yaml
+  - ./prometheus-rule.yaml

--- a/kubernetes/apps/ingress-system/external-dns-cloudflare/resources/prometheus-rule.yaml
+++ b/kubernetes/apps/ingress-system/external-dns-cloudflare/resources/prometheus-rule.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-dns-cloudflare
+spec:
+  groups:
+    - name: external-dns-cloudflare.rules
+      rules:
+        - alert: ExternalDNSCloudflareStale
+          expr: |-
+            time() - external_dns_controller_last_sync_timestamp_seconds{job="external-dns-cloudflare"} > 60
+          for: 5m
+          annotations:
+            summary: >-
+              ExternalDNS ({{ $labels.job }}) has not synced successfully in the last five minutes
+          labels:
+            severity: critical

--- a/kubernetes/apps/ingress-system/external-dns-unifi/resources/kustomization.yaml
+++ b/kubernetes/apps/ingress-system/external-dns-unifi/resources/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./external-secret.yaml
   - ./helm-release.yaml
+  - ./prometheus-rule.yaml

--- a/kubernetes/apps/ingress-system/external-dns-unifi/resources/prometheus-rule.yaml
+++ b/kubernetes/apps/ingress-system/external-dns-unifi/resources/prometheus-rule.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-dns-unifi
+spec:
+  groups:
+    - name: external-dns-unifi.rules
+      rules:
+        - alert: ExternalDNSUnifiStale
+          expr: |-
+            time() - external_dns_controller_last_sync_timestamp_seconds{job="external-dns-unifi"} > 60
+          for: 5m
+          annotations:
+            summary: >-
+              ExternalDNS ({{ $labels.job }}) has not synced successfully in the last five minutes
+          labels:
+            severity: critical

--- a/kubernetes/apps/ingress-system/external-proxy/resources/envoy-proxy.yaml
+++ b/kubernetes/apps/ingress-system/external-proxy/resources/envoy-proxy.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/envoyproxy/gateway/refs/heads/main/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -12,7 +12,7 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyDeployment:
-        replicas: 1
+        replicas: 2
         container:
           image: mirror.gcr.io/envoyproxy/envoy:v1.39.0
           resources:

--- a/kubernetes/apps/ingress-system/internal-proxy/resources/envoy-proxy.yaml
+++ b/kubernetes/apps/ingress-system/internal-proxy/resources/envoy-proxy.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/envoyproxy/gateway/refs/heads/main/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:


### PR DESCRIPTION
## Summary
- Add gatus checks for DNS resolution: internal (via router at 192.168.10.1) and public (via Quad9)
- Add a PrometheusRule per external-dns instance (cloudflare, unifi) alerting critical if sync goes stale for 5m
- Scale external-proxy to 2 replicas for HA
- Point envoy-proxy schema comments at the k8s-schemas.home-operations.com mirror instead of the upstream GitHub raw URL

## Test plan
- [ ] `flate diff` clean against cluster
- [ ] gatus shows both new DNS checks passing after sync
- [ ] Prometheus picks up both new rules (`kubectl get prometheusrule -n ingress-system`)
- [ ] external-proxy pods show 2/2 ready