### PR TITLE
fix(litellm): correct gatus healthcheck condition behind Cloudflare Access

### DIFF
--- a/kubernetes/apps/default/litellm/resources/http-route-external.yaml
+++ b/kubernetes/apps/default/litellm/resources/http-route-external.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: litellm-external
+  annotations:
+    gatus.home-operations.com/endpoint: |-
+      group: external
+      conditions: ["[STATUS] == 403"]
 spec:
   hostnames:
     - litellm.mcf.io

--- a/kubernetes/apps/default/litellm/resources/http-route.yaml
+++ b/kubernetes/apps/default/litellm/resources/http-route.yaml
@@ -4,6 +4,11 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: litellm
+  annotations:
+    gatus.home-operations.com/endpoint: |-
+      group: internal
+      url: https://litellm.milton.mcf.io/health/liveliness
+      conditions: ["[STATUS] == 200"]
 spec:
   hostnames:
     - litellm.milton.mcf.io


### PR DESCRIPTION
## Summary

litellm's external route (litellm.mcf.io) sits behind a Cloudflare Access service-token policy. gatus auto-discovers every HTTPRoute and checks it with a default `[STATUS] == 200` condition, so the external check was failing — Access rejects unauthenticated probes at the edge with 403 before the request reaches the tunnel or the pod, not because litellm was actually down.

- `litellm-external`: assert `[STATUS] == 403` instead of 200. This confirms Access is still enforcing; a different response would mean Access got disabled (litellm exposed publicly) or the tunnel has no live connector (Cloudflare returns its own error in that case).
- `litellm` (internal): point the check at `/health/liveliness` instead of the default root path, which just serves litellm's docs/landing page. `/health/liveliness` is litellm's actual liveness endpoint and doesn't depend on DB state.

Both are `gatus.home-operations.com/endpoint` annotations on the existing HTTPRoutes. No new secrets or Cloudflare Access wiring into gatus.